### PR TITLE
调整滚动行为和滚动增量

### DIFF
--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -154,7 +154,12 @@ void WebviewHandler::sendScrollEvent(int x, int y, int deltaX, int deltaY) {
         CefMouseEvent ev;
         ev.x = x;
         ev.y = y;
-        (*it)->GetHost()->SendMouseWheelEvent(ev, deltaX, deltaY);
+
+#ifndef __APPLE__
+        // The scrolling direction on Windows and Linux is different from MacOS
+        deltaY = -deltaY;
+#endif
+    (*it)->GetHost()->SendMouseWheelEvent(ev, deltaX, deltaY);
     }
 }
 

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -158,10 +158,13 @@ void WebviewHandler::sendScrollEvent(int x, int y, int deltaX, int deltaY) {
 #ifndef __APPLE__
         // The scrolling direction on Windows and Linux is different from MacOS
         deltaY = -deltaY;
-#endif
-
         // Flutter scrolls too slowly, it looks more normal by 10x default speed.
         (*it)->GetHost()->SendMouseWheelEvent(ev, deltaX * 10, deltaY * 10);
+#else
+        (*it)->GetHost()->SendMouseWheelEvent(ev, deltaX, deltaY);
+#endif
+
+
     }
 }
 

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -159,7 +159,9 @@ void WebviewHandler::sendScrollEvent(int x, int y, int deltaX, int deltaY) {
         // The scrolling direction on Windows and Linux is different from MacOS
         deltaY = -deltaY;
 #endif
-    (*it)->GetHost()->SendMouseWheelEvent(ev, deltaX, deltaY);
+
+        // Flutter scrolls too slowly, it looks more normal by 10x default speed.
+        (*it)->GetHost()->SendMouseWheelEvent(ev, deltaX * 10, deltaY * 10);
     }
 }
 


### PR DESCRIPTION
1. 调整 Windows/Linux 下垂直滚动方向适应平台默认的滚动行为；
2. 调整滚动增量，在 Windows 下这个增量非常小，大概乘以 10 倍之后速度看起来比较正常（没有在 MacOS 下测试，如果速度不一样的，需要单独调整）；