### PR TITLE
Grammatical Fixes & Markdown Linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,32 @@
 ## 0.0.8
-1.add support for build macos universal app
-2.refine scrolling for different platform
-3.add url bar search feature for example project
-4.add title & url change aware for ui
+
+- Added support to build macOS universal app.
+- Refined scrolling for different platform.
+- Added search bar features in example project.
+- Added title & url change aware in UI.
 
 ## 0.0.7
-1.basic characters input support.
-2.add back, forward, reload api.
-3.mouse move events support.
-4.html5 drag&drop support.
+
+- Basic characters input support.
+- Added back, forward, reload APIs.
+- Mouse move events support.
+- HTML5 drag & drop support.
 
 ## 0.0.6
-fix macos compile
+
+- Fixed macOS compile issue.
 
 ## 0.0.5
-1.🎉initial support for macos
-2.touchpad support (based on flutter 3.3)
-3.Hi-DPI display support
+
+1. Initial support for macOS.
+2. Touchpad support (based on flutter 3.3).
+3. Hi-DPI display support.
 
 ## 0.0.3
-fix compile issue on non-utf8 machines
+
+- Fixed compile issue on non-utf8 machines.
 
 ## 0.0.1
 
-* TODO: Describe initial release.
+- Webview CEF plugin for Flutter Desktop.
+- Windows support only.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,26 @@
 <a href="https://pub.dev/packages/webview_cef"><img src="https://img.shields.io/pub/likes/webview_cef?logo=dart" alt="Pub.dev likes"/></a> <a href="https://pub.dev/packages/webview_cef" alt="Pub.dev popularity"><img src="https://img.shields.io/pub/popularity/webview_cef?logo=dart"/></a> <a href="https://pub.dev/packages/webview_cef"><img src="https://img.shields.io/pub/points/webview_cef?logo=dart" alt="Pub.dev points"/></a> <a href="https://pub.dev/packages/webview_cef"><img src="https://img.shields.io/pub/v/webview_cef.svg" alt="latest version"/></a> <a href="https://pub.dev/packages/webview_cef"><img src="https://img.shields.io/badge/macOS%20%7C%20Windows-blue?logo=flutter" alt="Platform"/></a>
 
 Flutter Desktop WebView backed by CEF (Chromium Embedded Framework).
+This project is under heavy development, and the APIs are not stable yet.
 
-## Requirements
+## Index
 
-- Windows 7+
-- macOS 10.12+
+- [Supported OSs](#supported-oss)
+- [Setting Up](#setting-up)
+  - [Windows](#windows)
+  - [macOS](#macos)
+- [TODOs](#todos)
+- [Demo](#demo)
+  - [Screenshots](#screenshots)
+- [Credits](#credits)
 
-## How To Use
+## Supported OSs
+
+- [x] Windows 7+
+- [x] macOS 10.12+
+- [ ] [Linux (WIP)](https://github.com/hlwhl/webview_cef/tree/linux)
+
+## Setting Up
 
 ### Windows
 
@@ -26,11 +39,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
 When building the project for the first time, a prebuilt cef bin package (200MB, link in release) will be downloaded automatically, so you may wait for a longer time if you are building the project for the first time.
 
-## macOS
+### macOS
 
 1. Download prebuilt cef bundles from [arm64](https://github.com/hlwhl/webview_cef/releases/download/prebuilt_cef_bin_mac_arm64/CEFbins-mac103.0.12-arm64.zip) or [intel](https://github.com/hlwhl/webview_cef/releases/download/prebuilt_cef_bin_mac_intel/mac103.0.12-Intel.zip) depends on your target machine arch.
 
-> Note: You can also download [universal binary](https://github.com/hlwhl/webview_cef/releases/download/prebuilt_cef_bin_mac_universal/mac103.0.12-universal.zip) for build an mac-universal app if you want to build an mac universal app. See [#30](/../../issues/30). Thanks to @okiabrian123.
+> Note: You can also download [universal binary](https://github.com/hlwhl/webview_cef/releases/download/prebuilt_cef_bin_mac_universal/mac103.0.12-universal.zip) for build an mac-universal app if you want to build an mac universal app. See [#30](/../../issues/30). Thanks to [@okiabrian123](https://github.com/okiabrian123).
 
 2. Unzip the archive and put all files into `macos/third/cef`.
 
@@ -40,9 +53,9 @@ When building the project for the first time, a prebuilt cef bin package (200MB,
 
 > Note: Currently the project has not been enabled with multi process support due to debug convenience. If you want to enable multi process support, you may want to enable multi process mode by changing the implementation and build your own helper bundle. (Finding a more elegant way in the future.)
 
-## Todos
+## TODOs
 
-> PRs are welcome!
+> Pull requests are welcome.
 
 - [x] Windows support
 - [x] macOS support
@@ -52,28 +65,25 @@ When building the project for the first time, a prebuilt cef bin package (200MB,
 - [x] Mouse events support
 - [ ] JS bridge support
 - [x] Release to pub
-- [x] Trackpad support (flutter 3.3)
+- [x] Trackpad support
 - [ ] Better macOS binary distribution
-- [ ] Easier way to integrate macos helper bundles(multi process)
+- [ ] Easier way to integrate macOS helper bundles(multi process)
 - [x] devTools support
 
 ## Demo
 
-This demo is a simple webview app that can be used to test the webview_cef plugin.
+This demo is a simple webview app that can be used to test the `webview_cef` plugin.
 
-### In Windows
+<kbd>![demo_compressed](https://user-images.githubusercontent.com/7610615/190432410-c53ef1c4-33c2-461b-af29-b0ecab983579.gif)</kbd>
 
-![demo_compressed](https://user-images.githubusercontent.com/7610615/190432410-c53ef1c4-33c2-461b-af29-b0ecab983579.gif)
-![image](https://user-images.githubusercontent.com/7610615/190431027-6824fac1-015d-4091-b034-dd58f79adbcb.png)
-![image](https://user-images.githubusercontent.com/7610615/190431037-62ba0ea7-f7d1-4fca-8ce1-596a0a508f93.png)
-![image](https://user-images.githubusercontent.com/7610615/195815041-b9ec4da8-560f-4257-9303-f03a016da5c6.png)
+### Screenshots
 
-### In macOS
+| Windows | macOS |
+| --- | --- |
+| <img src="https://user-images.githubusercontent.com/7610615/190431027-6824fac1-015d-4091-b034-dd58f79adbcb.png" width="400" /> | <img src="https://user-images.githubusercontent.com/7610615/190911381-db88cf33-70a2-4abc-9916-e563e54eb3f9.png" width="400" /> |
+| <img src="https://user-images.githubusercontent.com/7610615/190431037-62ba0ea7-f7d1-4fca-8ce1-596a0a508f93.png" width="400" /> | <img src="https://user-images.githubusercontent.com/7610615/190911410-bd01e912-5482-4f9e-9dae-858874e5aaed.png" width="400" /> |
+| <img src="https://user-images.githubusercontent.com/7610615/195815041-b9ec4da8-560f-4257-9303-f03a016da5c6.png" width="400" /> | <img width="400" alt="image" src="https://user-images.githubusercontent.com/7610615/195818746-e5adf0ef-dc8c-48ad-9b11-e552ca65b08a.png"> |
 
-![image](https://user-images.githubusercontent.com/7610615/190911381-db88cf33-70a2-4abc-9916-e563e54eb3f9.png)
-![image](https://user-images.githubusercontent.com/7610615/190911410-bd01e912-5482-4f9e-9dae-858874e5aaed.png)
-<img width="1397" alt="image" src="https://user-images.githubusercontent.com/7610615/195818746-e5adf0ef-dc8c-48ad-9b11-e552ca65b08a.png">
+## Credits
 
-## Thanks
-
-This project is inspired from [**`flutter_webview_windows`**](https://github.com/jnschulze/flutter-webview-windows)
+This project is inspired from [**`flutter_webview_windows`**](https://github.com/jnschulze/flutter-webview-windows).

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This project is under heavy development, and the APIs are not stable yet.
 
 - [Supported OSs](#supported-oss)
 - [Setting Up](#setting-up)
-  - [Windows](#windows)
-  - [macOS](#macos)
+  - [Windows <img align="center" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Windows_logo_-_2021.svg/1200px-Windows_logo_-_2021.svg.png" width="12">](#windows)
+  - [macOS <img align="center" src="https://seeklogo.com/images/A/apple-logo-52C416BDDD-seeklogo.com.png" width="12">](#macos)
 - [TODOs](#todos)
 - [Demo](#demo)
   - [Screenshots](#screenshots)
@@ -18,13 +18,13 @@ This project is under heavy development, and the APIs are not stable yet.
 
 ## Supported OSs
 
-- [x] Windows 7+
-- [x] macOS 10.12+
-- [ ] [Linux (WIP)](https://github.com/hlwhl/webview_cef/tree/linux)
+- [x] Windows 7+ <img align="center" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Windows_logo_-_2021.svg/1200px-Windows_logo_-_2021.svg.png" width="12">
+- [x] macOS 10.12+ <img align="center" src="https://seeklogo.com/images/A/apple-logo-52C416BDDD-seeklogo.com.png" width="12">
+- [ ] [Linux (WIP) <img align="center" src="https://1000logos.net/wp-content/uploads/2017/03/LINUX-LOGO.png" width="14">](https://github.com/hlwhl/webview_cef/tree/linux)
 
 ## Setting Up
 
-### Windows
+### Windows <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Windows_logo_-_2021.svg/1200px-Windows_logo_-_2021.svg.png" width="16">
 
 Inside your application folder, you need to add two lines in your `windows\runner\main.cpp`.（Because of Chromium multi process architecture.)
 
@@ -39,7 +39,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
 When building the project for the first time, a prebuilt cef bin package (200MB, link in release) will be downloaded automatically, so you may wait for a longer time if you are building the project for the first time.
 
-### macOS
+### macOS <img src="https://seeklogo.com/images/A/apple-logo-52C416BDDD-seeklogo.com.png" width="15">
 
 1. Download prebuilt cef bundles from [arm64](https://github.com/hlwhl/webview_cef/releases/download/prebuilt_cef_bin_mac_arm64/CEFbins-mac103.0.12-arm64.zip) or [intel](https://github.com/hlwhl/webview_cef/releases/download/prebuilt_cef_bin_mac_intel/mac103.0.12-Intel.zip) depends on your target machine arch.
 
@@ -78,7 +78,7 @@ This demo is a simple webview app that can be used to test the `webview_cef` plu
 
 ### Screenshots
 
-| Windows | macOS |
+| Windows <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Windows_logo_-_2021.svg/1200px-Windows_logo_-_2021.svg.png" width="12"> | macOS <img src="https://seeklogo.com/images/A/apple-logo-52C416BDDD-seeklogo.com.png" width="11"> |
 | --- | --- |
 | <img src="https://user-images.githubusercontent.com/7610615/190431027-6824fac1-015d-4091-b034-dd58f79adbcb.png" width="400" /> | <img src="https://user-images.githubusercontent.com/7610615/190911381-db88cf33-70a2-4abc-9916-e563e54eb3f9.png" width="400" /> |
 | <img src="https://user-images.githubusercontent.com/7610615/190431037-62ba0ea7-f7d1-4fca-8ce1-596a0a508f93.png" width="400" /> | <img src="https://user-images.githubusercontent.com/7610615/190911410-bd01e912-5482-4f9e-9dae-858874e5aaed.png" width="400" /> |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: webview_cef
-description: Flutter Desktop Webview backed by CEF (Chromium Embedded Framework)
+description: Flutter Desktop Webview backed by CEF (Chromium Embedded Framework).
 version: 0.0.8
 homepage: https://github.com/hlwhl/webview_cef
+repository: https://github.com/hlwhl/webview_cef
 
 environment:
   sdk: ">=2.17.1 <3.0.0"
@@ -17,55 +18,10 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' specifies the class (in Java, Kotlin, Swift, Objective-C, etc.)
-  # which should be registered in the plugin registry. This is required for
-  # using method channels.
-  # The Android 'package' specifies package in which the registered class is.
-  # This is required for using method channels on Android.
-  # The 'ffiPlugin' specifies that native code should be built and bundled.
-  # This is required for using `dart:ffi`.
-  # All these are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       macos:
         pluginClass: WebviewCefPlugin
       windows:
         pluginClass: WebviewCefPluginCApi
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
Fixed multiple grammatical errors and linted `README.md` & `CHANGELOG.md` to look and feel more professional for developers to understand.

## Changes

- [x] Followed `markdownlint` rules in `README.md` & `CHANGELOG.md`.
- [x] Removed unnecessary boilerplate comments from `pubspec.yaml`.
- [x] Made `## Demo` section in `README.md` look and feel better.
- [x] Added `## Index` section in `README.md` to let developers go to any section easily.
- [x] Added Windows, macOS & Linux logos in `README.md`.