### PR TITLE
[Dart 2]Fix null safety: If there is a MaterialApp, OverlayState cannot be null.

### DIFF
--- a/common/webview_app.h
+++ b/common/webview_app.h
@@ -28,6 +28,7 @@ public:
                                        CefRefPtr<CefCommandLine> command_line) override {
                                            command_line->AppendSwitch("disable-gpu");
                                            command_line->AppendSwitch("disable-gpu-compositing");
+                                           command_line->AppenSwitch("disable-web-security");
                                            #ifdef __APPLE__
                                                 command_line->AppendSwitch("use-mock-keychain");
                                                 command_line->AppendSwitch("single-process");

--- a/common/webview_app.h
+++ b/common/webview_app.h
@@ -28,7 +28,7 @@ public:
                                        CefRefPtr<CefCommandLine> command_line) override {
                                            command_line->AppendSwitch("disable-gpu");
                                            command_line->AppendSwitch("disable-gpu-compositing");
-                                           command_line->AppenSwitch("disable-web-security");
+                                           command_line->AppendSwitch("disable-web-security");
                                            #ifdef __APPLE__
                                                 command_line->AppendSwitch("use-mock-keychain");
                                                 command_line->AppendSwitch("single-process");

--- a/common/webview_app.h
+++ b/common/webview_app.h
@@ -26,7 +26,10 @@ public:
     void OnBeforeCommandLineProcessing(
                                        const CefString& process_type,
                                        CefRefPtr<CefCommandLine> command_line) override {
-                                           command_line->AppendSwitch("disable-gpu");
+                                           command_line->AppendSwitch("enable-gpu");
+                                        //    command_line->AppendSwitch("use-gl");
+                                           command_line->AppendSwitch("in-process-gpu");
+                                        //    command_line->AppendSwitch("disable-gpu");
                                            command_line->AppendSwitch("disable-gpu-compositing");
                                            command_line->AppendSwitch("disable-web-security");
                                            #ifdef __APPLE__

--- a/lib/src/webview_tooltip.dart
+++ b/lib/src/webview_tooltip.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 class WebviewTooltip {
   WebviewTooltip(BuildContext context) {
-    _overlayState = Overlay.of(context);
+    _overlayState = Overlay.of(context)!;
     _box = context.findRenderObject() as RenderBox;
   }
   late OverlayState _overlayState;


### PR DESCRIPTION
Purpose: Make sure this package can run on Dart 2.