### PR TITLE
add main test for webview

### DIFF
--- a/test/webview_main_test.dart
+++ b/test/webview_main_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:webview_cef_example/main.dart';
+
+void main() {
+  testWidgets('Verify the button changes text upon click', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(const MyApp());
+
+    // Verify initial button text
+    final initialTextFinder = find.text('Click me');
+    expect(initialTextFinder, findsOneWidget);
+
+    // Tap the button which should change its text
+    await tester.tap(initialTextFinder);
+    await tester.pump();  // Rebuild the widget after the state has changed
+
+    // Verify the button's text has changed after being clicked
+    expect(find.text('Clicked!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
This pull request introduces a new widget test for the `MyApp` application within the `webview_cef_example` project. The test is designed to verify the functionality of a button that changes its displayed text upon being clicked.

**Key Features of the Test:**
- The test initializes the application and simulates the UI up to the first frame.
- It locates a button initially labeled "Click me" and confirms its presence in the widget tree.
- The test simulates a user tapping the button.
- After the tap, it checks to ensure the button's text updates to "Clicked!" to reflect the user interaction.

This test ensures that the button's dynamic text change functionality works as expected, providing a reliable user experience. It's a part of ongoing efforts to enhance test coverage and ensure UI components behave correctly under user interactions.