### PR TITLE
feat: add UserScript Inject logic

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:webview_cef/webview_cef.dart';
+import 'package:webview_cef/src/webview_inject_user_script.dart';
 
 void main() {
   runApp(const MyApp());
@@ -16,6 +17,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   late WebViewController _controller;
+
   // late WebViewController _controller2;
   final _textController = TextEditingController();
   String title = "";
@@ -23,8 +25,30 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void initState() {
-    _controller =
-        WebviewManager().createWebView(loading: const Text("not initialized"));
+    var injectUserScripts = InjectUserScripts();
+    injectUserScripts.add(UserScript("console.log('injectScript_in_LoadStart')",
+        ScriptInjectTime.LOAD_START));
+    injectUserScripts.add(UserScript(
+        "console.log('injectScript_in_LoadEnd')", ScriptInjectTime.LOAD_END));
+
+    // CSS Injection Script Example
+    // injectUserScripts.add(UserScript(
+    //   '''
+    //     const style = document.createElement('style');
+    //     style.innerHTML = `
+    //       body {
+    //         background-color: yellow;
+    //       }
+    //     `;
+    //
+    //     document.head.appendChild(style);
+    //   ''',
+    //   ScriptInjectTime.LOAD_END,
+    // ));
+
+    _controller = WebviewManager().createWebView(
+        loading: const Text("not initialized"),
+        injectUserScripts: injectUserScripts);
     // _controller2 =
     //     WebviewManager().createWebView(loading: const Text("not initialized"));
     super.initState();

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:webview_cef/src/webview_inject_user_script.dart';
 
 import 'webview_manager.dart';
 import 'webview_events_listener.dart';

--- a/lib/src/webview_inject_user_script.dart
+++ b/lib/src/webview_inject_user_script.dart
@@ -1,0 +1,24 @@
+enum ScriptInjectTime { LOAD_START, LOAD_END }
+
+class UserScript {
+  final String script;
+  final ScriptInjectTime injectTime;
+
+  UserScript(this.script, this.injectTime);
+}
+
+class InjectUserScripts {
+  List<UserScript> userScripts = [];
+
+  void add(UserScript script) {
+    userScripts.add(script);
+  }
+
+  List<UserScript>? retrieveLoadStartInjectScripts() {
+    return userScripts.where((e) => e.injectTime == ScriptInjectTime.LOAD_START).toList();
+  }
+
+  List<UserScript>? retrieveLoadEndInjectScripts() {
+    return userScripts.where((e) => e.injectTime == ScriptInjectTime.LOAD_END).toList();
+  }
+}

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -134,7 +134,7 @@ class WebviewManager extends ValueNotifier<bool> {
         int browserId = call.arguments["browserId"] as int;
         String urlId = call.arguments["urlId"] as String;
 
-        _injectUserScriptIfNeeds(browserId, _injectUserScripts?.retrieveLoadStartInjectScripts());
+        await _injectUserScriptIfNeeds(browserId, _injectUserScripts?.retrieveLoadStartInjectScripts());
 
         WebViewController controller =
         _webViews[browserId] as WebViewController;
@@ -144,7 +144,7 @@ class WebviewManager extends ValueNotifier<bool> {
         int browserId = call.arguments["browserId"] as int;
         String urlId = call.arguments["urlId"] as String;
 
-        _injectUserScriptIfNeeds(browserId, _injectUserScripts?.retrieveLoadEndInjectScripts());
+        await _injectUserScriptIfNeeds(browserId, _injectUserScripts?.retrieveLoadEndInjectScripts());
 
         WebViewController controller =
         _webViews[browserId] as WebViewController;


### PR DESCRIPTION
Suggest adding logic to execute javascript when the browser starts loading and when it finishes loading.
This will allow developers to inject CSS and JavaScript whenever they want, which will allow for more feature development.
We've added it to main.dart in the example.
Below is the code we set up to inject CSS via JavaScript.

```swift
var injectUserScripts = InjectUserScripts();

injectUserScripts.add(UserScript(
  '''
    const style = document.createElement('style');
    style.innerHTML = `
      body {
        background-color: yellow;
      }
    `;

    document.head.appendChild(style);
  ''',
  ScriptInjectTime.LOAD_END,
));

_controller = WebviewManager().createWebView(loading: const Text("not initialized"), injectUserScripts: injectUserScripts);
```

<table>
  <tr>
    <td align="center">Before</td>
    <td align="center">After</td>
  </tr>
  <tr>
    <td align="center"><img width="1000" alt="" src="https://github.com/user-attachments/assets/250beb6a-c5eb-4e9c-b546-9cab57c134e7"></td>
    <td align="center"><img width="1000" alt="" src="https://github.com/user-attachments/assets/6e4a89b9-6931-4574-bb4e-d815bc8b81ba"></td>
  </tr>
</table>