### PR TITLE
feat: support int/double/bool/ArrayList type in evaluateJavascript method

### DIFF
--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -73,7 +73,7 @@ bool WebviewHandler::OnProcessMessageReceived(
         CefString callbackId = message->GetArgumentList()->GetString(0);
         CefRefPtr<CefValue> param = message->GetArgumentList()->GetValue(1);
 
-        if(!callbackId.empty() && param->IsValid()){
+        if(!callbackId.empty()){
             auto it = js_callbacks_.find(callbackId.ToString());
             if(it != js_callbacks_.end()){
                 it->second(param);

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -588,8 +588,6 @@ void WebviewHandler::executeJavaScript(int browserId, const std::string code, st
                 if(callback != nullptr){
                     std::string callbackId = GetCallbackId();
 
-                    printf("CallbackId: %s\n", callbackId.c_str());
-
                     finalCode = "external.EvaluateCallback('";
                     finalCode += callbackId;
                     finalCode += "',(function(){return ";

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -71,11 +71,12 @@ bool WebviewHandler::OnProcessMessageReceived(
     }
     else if(message_name == kEvaluateCallbackMessage){
         CefString callbackId = message->GetArgumentList()->GetString(0);
-        CefString param = message->GetArgumentList()->GetString(1);
-        if(!callbackId.empty() && !param.empty()){
+        CefRefPtr<CefValue> param = message->GetArgumentList()->GetValue(1);
+
+        if(!callbackId.empty() && param->IsValid()){
             auto it = js_callbacks_.find(callbackId.ToString());
             if(it != js_callbacks_.end()){
-                it->second(param.ToString());
+                it->second(param);
                 js_callbacks_.erase(it);
             }
         }
@@ -574,7 +575,7 @@ static std::string GetCallbackId()
     return std::to_string(timestamp);
 } 
 
-void WebviewHandler::executeJavaScript(int browserId, const std::string code, std::function<void(std::string)> callback)
+void WebviewHandler::executeJavaScript(int browserId, const std::string code, std::function<void(CefRefPtr<CefValue>)> callback)
 {
     if(!code.empty())
     {
@@ -586,6 +587,9 @@ void WebviewHandler::executeJavaScript(int browserId, const std::string code, st
                 std::string finalCode = code;
                 if(callback != nullptr){
                     std::string callbackId = GetCallbackId();
+
+                    printf("CallbackId: %s\n", callbackId.c_str());
+
                     finalCode = "external.EvaluateCallback('";
                     finalCode += callbackId;
                     finalCode += "',(function(){return ";

--- a/common/webview_handler.h
+++ b/common/webview_handler.h
@@ -6,6 +6,8 @@
 #define CEF_TESTS_CEFSIMPLE_SIMPLE_HANDLER_H_
 
 #include "include/cef_client.h"
+#include "include/cef_base.h"
+#include "include/cef_app.h"
 
 #include <functional>
 #include <list>
@@ -168,13 +170,13 @@ public:
 
     void setJavaScriptChannels(int browserId, const std::vector<std::string> channels);
     void sendJavaScriptChannelCallBack(const bool error, const std::string result, const std::string callbackId, const int browserId, const std::string frameId);
-    void executeJavaScript(int browserId, const std::string code, std::function<void(std::string)> callback = nullptr);
+    void executeJavaScript(int browserId, const std::string code, std::function<void(CefRefPtr<CefValue>)> callback = nullptr);
     
 private:
     // List of existing browser windows. Only accessed on the CEF UI thread.
     std::unordered_map<int, browser_info> browser_map_;
 
-    std::unordered_map<std::string, std::function<void(std::string)>> js_callbacks_;    
+    std::unordered_map<std::string, std::function<void(CefRefPtr<CefValue>)>> js_callbacks_;
     // Include the default reference counting implementation.
     IMPLEMENT_REFCOUNTING(WebviewHandler);
 

--- a/common/webview_handler.h
+++ b/common/webview_handler.h
@@ -6,8 +6,6 @@
 #define CEF_TESTS_CEFSIMPLE_SIMPLE_HANDLER_H_
 
 #include "include/cef_client.h"
-#include "include/cef_base.h"
-#include "include/cef_app.h"
 
 #include <functional>
 #include <list>

--- a/common/webview_js_handler.cc
+++ b/common/webview_js_handler.cc
@@ -3,290 +3,427 @@
 
 std::atomic_long s_nReqID {1001};
 
+// CefV8Value에서 JSValue로 변환
+JSValue ConvertCefV8ValueToJSValue(CefRefPtr<CefV8Value> value) {
+    JSValue result;
+
+    if (value->IsString()) {
+        printf("[Carrick]----1\n");
+        result.type = JSValue::Type::STRING;
+        result.stringValue = value->GetStringValue().ToString();
+    } else if (value->IsInt()) {
+        printf("[Carrick]----2\n");
+        result.type = JSValue::Type::INT;
+        result.intValue = value->GetIntValue();
+    } else if (value->IsBool()) {
+        printf("[Carrick]----3\n");
+        result.type = JSValue::Type::BOOL;
+        result.boolValue = value->GetBoolValue();  // 불리언 값을 가져옴
+    } else if (value->IsDouble()) {
+        printf("[Carrick]----4\n");
+        result.type = JSValue::Type::DOUBLE;
+        result.doubleValue = value->GetDoubleValue();
+    } else if (value->IsArray()) {
+        printf("[Carrick]----5\n");
+        result.type = JSValue::Type::ARRAY;
+        int length = value->GetArrayLength();
+        for (int i = 0; i < length; ++i) {
+            result.arrayValue.push_back(ConvertCefV8ValueToJSValue(value->GetValue(i)));
+        }
+    } else {
+        result.type = JSValue::Type::UNKNOWN;
+    }
+
+    return result;
+}
+
 bool CefJSHandler::Execute(const CefString& name,
-	CefRefPtr<CefV8Value> object,
-	const CefV8ValueList& arguments,
-	CefRefPtr<CefV8Value>& retval,
-	CefString& exception)
+                           CefRefPtr<CefV8Value> object,
+                           const CefV8ValueList& arguments,
+                           CefRefPtr<CefV8Value>& retval,
+                           CefString& exception)
 {
-	if (name == "jsCmd")
-	{
-		if (arguments.size() < 2) {
-			exception = "Invalid arguments.";
-			return true;
-		}
-		//the first param is function name,the last param is callback function,and allow most 2 custom params between them.
-		CefString function_name = arguments[0]->GetStringValue();
-		CefString params = "";
-		CefRefPtr<CefV8Value> callback;
-		CefRefPtr<CefV8Value> rawdata;
-		if (arguments[0]->IsString() && arguments[1]->IsFunction())
-		{
-			callback = arguments[1];
-		}
-		else if (arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsFunction())
-		{
-			params = arguments[1]->GetStringValue();
-			callback = arguments[2];
-		}
-		else if (arguments[0]->IsString() && arguments[1]->IsString() && arguments[3]->IsFunction())
-		{
-			params = arguments[1]->GetStringValue();
-			rawdata = arguments[2];
-			callback = arguments[3];
-		}
-		else
-		{
-			exception = "Invalid arguments.";
-			return true;
-		}
+    if (name == "jsCmd")
+    {
+        if (arguments.size() < 2) {
+            exception = "Invalid arguments.";
+            return true;
+        }
+        //the first param is function name,the last param is callback function,and allow most 2 custom params between them.
+        CefString function_name = arguments[0]->GetStringValue();
+        CefString params = "";
+        CefRefPtr<CefV8Value> callback;
+        CefRefPtr<CefV8Value> rawdata;
+        if (arguments[0]->IsString() && arguments[1]->IsFunction())
+        {
+            callback = arguments[1];
+        }
+        else if (arguments[0]->IsString() && arguments[1]->IsString() && arguments[2]->IsFunction())
+        {
+            params = arguments[1]->GetStringValue();
+            callback = arguments[2];
+        }
+        else if (arguments[0]->IsString() && arguments[1]->IsString() && arguments[3]->IsFunction())
+        {
+            params = arguments[1]->GetStringValue();
+            rawdata = arguments[2];
+            callback = arguments[3];
+        }
+        else
+        {
+            exception = "Invalid arguments.";
+            return true;
+        }
 
-		//call c++ funtion
-		if (!js_bridge_->CallCppFunction(function_name, params, callback, rawdata))
-		{
-			std::ostringstream strStream;
-			strStream << "Failed to call function:  " << function_name.c_str() << ".";
-			strStream.flush();
+        //call c++ funtion
+        if (!js_bridge_->CallCppFunction(function_name, params, callback, rawdata))
+        {
+            std::ostringstream strStream;
+            strStream << "Failed to call function:  " << function_name.c_str() << ".";
+            strStream.flush();
 
-			exception = strStream.str();
-		}
+            exception = strStream.str();
+        }
 
-	}
-	else if (name == "StartRequest")
-	{
-		if (arguments.size() < 5) {
-			exception = "Invalid arguments.";
-			return true;
-		}
-		// args[0]
-		int reqId = (int)arguments[0]->GetIntValue();
+    }
+    else if (name == "StartRequest")
+    {
+        if (arguments.size() < 5) {
+            exception = "Invalid arguments.";
+            return true;
+        }
+        // args[0]
+        int reqId = (int)arguments[0]->GetIntValue();
 
-		// args[1]
-		CefString strCmd = arguments[1]->GetStringValue();
+        // args[1]
+        CefString strCmd = arguments[1]->GetStringValue();
 
-		//// args[2]
-		CefString strCallback = arguments[2]->GetStringValue();
+        //// args[2]
+        CefString strCallback = arguments[2]->GetStringValue();
 
-		//// args[3]
-		CefString strArgs = arguments[3]->GetStringValue();
+        //// args[3]
+        CefString strArgs = arguments[3]->GetStringValue();
 
-		// call c++ function
-		if (!js_bridge_->StartRequest(reqId, strCmd, strCallback, strArgs))
-		{
-			std::ostringstream strStream;
-			strStream << "Failed to call function:  " << strCmd.c_str() << ".";
-			strStream.flush();
+        // call c++ function
+        if (!js_bridge_->StartRequest(reqId, strCmd, strCallback, strArgs))
+        {
+            std::ostringstream strStream;
+            strStream << "Failed to call function:  " << strCmd.c_str() << ".";
+            strStream.flush();
 
-			exception = strStream.str();
-		}
+            exception = strStream.str();
+        }
 
-	}
-	else if (name == "GetNextReqID")
-	{
-		int reqID = CefJSBridge::GetNextReqID();
-		retval = CefV8Value::CreateInt(reqID);
-	}
-	else if (name == "EvaluateCallback") {
-		CefString callbackId = arguments[0]->GetStringValue();
-		CefString result = arguments[1]->GetStringValue();
-		if (!js_bridge_->EvaluateCallback(callbackId, result)) {
-			std::ostringstream strStream;
-			strStream << "Failed to callback:  " << callbackId.c_str() << ".";
-			strStream.flush();
+    }
+    else if (name == "GetNextReqID")
+    {
+        int reqID = CefJSBridge::GetNextReqID();
+        retval = CefV8Value::CreateInt(reqID);
+    }
+    else if (name == "EvaluateCallback") {
+        CefString callbackId = arguments[0]->GetStringValue();
+        CefRefPtr<CefV8Value> result = arguments[1];
 
-			exception = strStream.str();
-		}
-	}
-	else {
-		exception = "NativeHost no this fun.";
-	}
+        JSValue jsValue = ConvertCefV8ValueToJSValue(result);
 
-	return true;
+        if (jsValue.type == JSValue::Type::STRING) {
+            std::cout << "String value: " << jsValue.stringValue << std::endl;
+        } else if (jsValue.type == JSValue::Type::INT) {
+            std::cout << "Int value: " << jsValue.intValue << std::endl;
+        } else if (jsValue.type == JSValue::Type::BOOL) {
+            std::cout << "Bool value: " << (jsValue.boolValue ? "true" : "false") << std::endl;
+        } else if (jsValue.type == JSValue::Type::DOUBLE) {
+            std::cout << "Double value: " << jsValue.doubleValue << std::endl;
+        } else if (jsValue.type == JSValue::Type::ARRAY) {
+            std::cout << "Array value: [";
+            for (const auto& element : jsValue.arrayValue) {
+                if (element.type == JSValue::Type::STRING) {
+                    std::cout << element.stringValue << ", ";
+                }
+            }
+            std::cout << "]" << std::endl;
+        } else if (jsValue.type == JSValue::Type::OBJECT) {
+            std::cout << "Object value: {";
+            for (const auto& kv : jsValue.objectValue) {
+                std::cout << kv.first << ": " << kv.second.stringValue << ", ";
+            }
+            std::cout << "}" << std::endl;
+        }
+
+        printf("EvaluateCallback: %s, %s\n", callbackId.ToString().c_str(), "A");
+        if (!js_bridge_->EvaluateCallback(callbackId, jsValue)) {
+            //        if (!js_bridge_->EvaluateCallback(callbackId, result)) {
+            std::ostringstream strStream;
+            strStream << "Failed to callback:  " << callbackId.c_str() << ".";
+            strStream.flush();
+
+            exception = strStream.str();
+        }
+    }
+    else {
+        exception = "NativeHost no this fun.";
+    }
+
+    return true;
 }
 
 bool CefJSBridge::StartRequest(int reqId,
-	const CefString& strCmd,
-	const CefString& strCallback,
-	const CefString& strArgs)
+                               const CefString& strCmd,
+                               const CefString& strCallback,
+                               const CefString& strArgs)
 {
-	if (reqId > 0) {
-		reqId *= -1;
-	}
+    if (reqId > 0) {
+        reqId *= -1;
+    }
 
-	auto it = startRequest_callback_.find(reqId);
-	if (it == startRequest_callback_.cend())
-	{
-		CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
-		if (context)
-		{
-			CefRefPtr<CefFrame> frame = context->GetFrame();
-			if (frame)
-			{
-				CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(kJSCallCppFunctionMessage);
-				message->GetArgumentList()->SetString(0, strCmd);
-				message->GetArgumentList()->SetString(1, strArgs);
-				message->GetArgumentList()->SetInt(2, reqId);
-				startRequest_callback_.emplace(reqId, std::make_pair(frame, strCallback));
-				frame->SendProcessMessage(PID_BROWSER, message);
-				return true;
-			}
-		}
-	}
+    auto it = startRequest_callback_.find(reqId);
+    if (it == startRequest_callback_.cend())
+    {
+        CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
+        if (context)
+        {
+            CefRefPtr<CefFrame> frame = context->GetFrame();
+            if (frame)
+            {
+                CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(kJSCallCppFunctionMessage);
+                message->GetArgumentList()->SetString(0, strCmd);
+                message->GetArgumentList()->SetString(1, strArgs);
+                message->GetArgumentList()->SetInt(2, reqId);
+                startRequest_callback_.emplace(reqId, std::make_pair(frame, strCallback));
+                frame->SendProcessMessage(PID_BROWSER, message);
+                return true;
+            }
+        }
+    }
 
-	return false;
+    return false;
+}
+
+bool CefJSBridge::EvaluateCallback(const CefString& callbackId, const CefRefPtr<CefV8Value> result) {
+    CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
+    if(context){
+        CefRefPtr<CefFrame> frame = context->GetFrame();
+        if(frame){
+            CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(kEvaluateCallbackMessage);
+            message->GetArgumentList()->SetString(0, callbackId);
+            //            message->GetArgumentList()->SetValue(1, result);
+            frame->SendProcessMessage(PID_BROWSER, message);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CefJSBridge::EvaluateCallback(const CefString& callbackId, const JSValue& result) {
+    CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
+    if (context) {
+        CefRefPtr<CefFrame> frame = context->GetFrame();
+        if (frame) {
+            CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(
+                                                                             kEvaluateCallbackMessage);
+            CefRefPtr<CefListValue> args = message->GetArgumentList();
+
+            args->SetString(0, callbackId);
+
+            switch (result.type) {
+                case JSValue::Type::STRING:
+                    args->SetString(1, result.stringValue);
+                    break;
+                case JSValue::Type::INT:
+                    args->SetInt(1, result.intValue);
+                    break;
+                case JSValue::Type::BOOL:
+                    args->SetBool(1, result.boolValue);
+                    break;
+                case JSValue::Type::DOUBLE:
+                    args->SetDouble(1, result.doubleValue);
+                    break;
+                case JSValue::Type::ARRAY: {
+                    // 배열 처리
+                    CefRefPtr<CefListValue> arrayList = CefListValue::Create();
+                    for (size_t i = 0; i < result.arrayValue.size(); ++i) {
+                        const JSValue &element = result.arrayValue[i];
+                        switch (element.type) {
+                            case JSValue::Type::STRING:
+                                arrayList->SetString(i, element.stringValue);
+                                break;
+                            case JSValue::Type::INT:
+                                arrayList->SetInt(i, element.intValue);
+                                break;
+                            case JSValue::Type::BOOL:
+                                arrayList->SetBool(i, element.boolValue);
+                                break;
+                            case JSValue::Type::DOUBLE:
+                                arrayList->SetDouble(i, element.doubleValue);
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    args->SetList(1, arrayList);
+                    break;
+                }
+            }
+
+            // 메시지 전송
+            frame->SendProcessMessage(PID_BROWSER, message);
+            return true;
+        }
+    }
+    return false;
 }
 
 bool CefJSBridge::EvaluateCallback(const CefString& callbackId, const CefString& result){
-	CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
-	if(context){
-		CefRefPtr<CefFrame> frame = context->GetFrame();
-		if(frame){
-			CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(kEvaluateCallbackMessage);
-			message->GetArgumentList()->SetString(0, callbackId);
-			message->GetArgumentList()->SetString(1, result);
-			frame->SendProcessMessage(PID_BROWSER, message);
-			return true;
-		}
-	}
-	return false;
+    CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
+    if(context){
+        CefRefPtr<CefFrame> frame = context->GetFrame();
+        if(frame){
+            CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(kEvaluateCallbackMessage);
+            message->GetArgumentList()->SetString(0, callbackId);
+            message->GetArgumentList()->SetString(1, result);
+            frame->SendProcessMessage(PID_BROWSER, message);
+            return true;
+        }
+    }
+    return false;
 }
 
 
 int CefJSBridge::GetNextReqID()
 {
-	long nRet = ++s_nReqID;
-	if (nRet < 0)
-	{
-		nRet = 0;
-	}
+    long nRet = ++s_nReqID;
+    if (nRet < 0)
+    {
+        nRet = 0;
+    }
 
-	while (nRet == 0)
-	{
-		nRet = ++s_nReqID;
-	}
+    while (nRet == 0)
+    {
+        nRet = ++s_nReqID;
+    }
 
-	return nRet;
+    return nRet;
 }
 
 bool CefJSBridge::CallCppFunction(const CefString& function_name,
-	const CefString& params,
-	CefRefPtr<CefV8Value> callback,
-	CefRefPtr<CefV8Value> rawdata)
+                                  const CefString& params,
+                                  CefRefPtr<CefV8Value> callback,
+                                  CefRefPtr<CefV8Value> rawdata)
 {
-	auto it = render_callback_.find(js_callback_id_);
-	if (it == render_callback_.cend())
-	{
-		CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
-		if (context)
-		{
-			CefRefPtr<CefFrame> frame = context->GetFrame();
-			if (frame)
-			{
-				CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(kJSCallCppFunctionMessage);
-				message->GetArgumentList()->SetString(0, function_name);
-				message->GetArgumentList()->SetString(1, params);
-				message->GetArgumentList()->SetInt(2, js_callback_id_);
-				render_callback_.emplace(js_callback_id_++, std::make_pair(context, std::make_pair(callback, rawdata)));
-				frame->SendProcessMessage(PID_BROWSER, message);
-				return true;
-			}
-		}
-	}
+    auto it = render_callback_.find(js_callback_id_);
+    if (it == render_callback_.cend())
+    {
+        CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
+        if (context)
+        {
+            CefRefPtr<CefFrame> frame = context->GetFrame();
+            if (frame)
+            {
+                CefRefPtr<CefProcessMessage> message = CefProcessMessage::Create(kJSCallCppFunctionMessage);
+                message->GetArgumentList()->SetString(0, function_name);
+                message->GetArgumentList()->SetString(1, params);
+                message->GetArgumentList()->SetInt(2, js_callback_id_);
+                render_callback_.emplace(js_callback_id_++, std::make_pair(context, std::make_pair(callback, rawdata)));
+                frame->SendProcessMessage(PID_BROWSER, message);
+                return true;
+            }
+        }
+    }
 
-	return false;
+    return false;
 }
 
 
 void CefJSBridge::RemoveCallbackFuncWithFrame(CefRefPtr<CefFrame> frame)
 {
-	if (!render_callback_.empty()) {
-		for (auto it = render_callback_.begin(); it != render_callback_.end();) {
-			if (it->second.first->IsSame(frame->GetV8Context())) {
-				it = render_callback_.erase(it);
-			}
-			else {
-				++it;
-			}
-		}
-	}
+    if (!render_callback_.empty()) {
+        for (auto it = render_callback_.begin(); it != render_callback_.end();) {
+            if (it->second.first->IsSame(frame->GetV8Context())) {
+                it = render_callback_.erase(it);
+            }
+            else {
+                ++it;
+            }
+        }
+    }
 
-	if (!startRequest_callback_.empty()) {
-		for (auto it = startRequest_callback_.begin(); it != startRequest_callback_.end();) {
-			if (it->second.first->GetIdentifier() == frame->GetIdentifier()) {
-				it = startRequest_callback_.erase(it);
-			}
-			else {
-				++it;
-			}
-		}
-	}
+    if (!startRequest_callback_.empty()) {
+        for (auto it = startRequest_callback_.begin(); it != startRequest_callback_.end();) {
+            if (it->second.first->GetIdentifier() == frame->GetIdentifier()) {
+                it = startRequest_callback_.erase(it);
+            }
+            else {
+                ++it;
+            }
+        }
+    }
 }
 
 bool CefJSBridge::ExecuteJSCallbackFunc(int callbackId, bool error, const CefString& result)
 {
-	if (callbackId < 0)
-	{
-		auto it = startRequest_callback_.find(callbackId);
-		if (it != startRequest_callback_.cend())
-		{
-			auto frame = it->second.first;
-			CefString callback = it->second.second;
+    if (callbackId < 0)
+    {
+        auto it = startRequest_callback_.find(callbackId);
+        if (it != startRequest_callback_.cend())
+        {
+            auto frame = it->second.first;
+            CefString callback = it->second.second;
 
-			if (callback != "" && frame.get())
-			{
-				std::ostringstream strStream;
-				strStream <<"window['" << callback.ToString() << "'](" << callbackId * -1 << ", " << result.ToString() << ");";
-				strStream.flush();
+            if (callback != "" && frame.get())
+            {
+                std::ostringstream strStream;
+                strStream <<"window['" << callback.ToString() << "'](" << callbackId * -1 << ", " << result.ToString() << ");";
+                strStream.flush();
 
-				CefString strCode = strStream.str();
-				frame->ExecuteJavaScript(strCode, frame->GetURL(), 0);
-				startRequest_callback_.erase(callbackId);
+                CefString strCode = strStream.str();
+                frame->ExecuteJavaScript(strCode, frame->GetURL(), 0);
+                startRequest_callback_.erase(callbackId);
 
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
-	}
-	else
-	{
-		auto it = render_callback_.find(callbackId);
-		if (it != render_callback_.cend())
-		{
-			auto context = it->second.first;
-			auto callback = it->second.second.first;
-			auto rawdata = it->second.second.second;
-			if (context.get() && callback.get())
-			{
-				context->Enter();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+    else
+    {
+        auto it = render_callback_.find(callbackId);
+        if (it != render_callback_.cend())
+        {
+            auto context = it->second.first;
+            auto callback = it->second.second.first;
+            auto rawdata = it->second.second.second;
+            if (context.get() && callback.get())
+            {
+                context->Enter();
 
-				CefV8ValueList arguments;
+                CefV8ValueList arguments;
 
-				//the first param marks whether the function execution result was successful
-				arguments.push_back(CefV8Value::CreateBool(error));
+                //the first param marks whether the function execution result was successful
+                arguments.push_back(CefV8Value::CreateBool(error));
 
-				// the second prarm take the return data
-				arguments.push_back(CefV8Value::CreateString(result));
-				if (rawdata.get()) {
-					arguments.push_back(rawdata);
-				}
+                // the second prarm take the return data
+                arguments.push_back(CefV8Value::CreateString(result));
+                if (rawdata.get()) {
+                    arguments.push_back(rawdata);
+                }
 
-				// call js function
-				CefRefPtr<CefV8Value> retval = callback->ExecuteFunction(nullptr, arguments);
-				context->Exit();
-				render_callback_.erase(callbackId);
+                // call js function
+                CefRefPtr<CefV8Value> retval = callback->ExecuteFunction(nullptr, arguments);
+                context->Exit();
+                render_callback_.erase(callbackId);
 
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
 
-	}
+    }
 
-	return false;
+    return false;
 }

--- a/common/webview_js_handler.h
+++ b/common/webview_js_handler.h
@@ -12,6 +12,20 @@ static const char kExecuteJsCallbackMessage[] = "ExecuteJsCallback";		 //c++ cal
 static const char kEvaluateCallbackMessage[] = "EvaluateCallback";		 //js callback c++ message
 static const char kFocusedNodeChangedMessage[] = "FocusedNodeChanged";		 //elements that capture focus in web pages changed message
 
+struct JSValue {
+    enum class Type { STRING, INT, BOOL, DOUBLE, ARRAY, OBJECT, UNKNOWN } type;
+
+    std::string stringValue;
+    int intValue;
+    bool boolValue;
+    double doubleValue;
+
+    std::vector<JSValue> arrayValue;
+    std::map<std::string, JSValue> objectValue;
+
+    JSValue() : type(Type::UNKNOWN) {}
+};
+
 class CefJSBridge
 {
 	typedef std::map<int/* js_callback_id*/, std::pair<CefRefPtr<CefV8Context>/* context*/, std::pair<CefRefPtr<CefV8Value>/* callback*/, CefRefPtr<CefV8Value>/* rawdata*/>>> RenderCallbackMap;
@@ -24,6 +38,8 @@ public:
 	static int  GetNextReqID();
 	bool StartRequest(int reqId, const CefString& strCmd, const CefString& strCallback, const CefString& strArgs);
 	bool EvaluateCallback(const CefString& callbackId, const CefString& result);
+    bool EvaluateCallback(const CefString& callbackId, const JSValue& result);
+    bool EvaluateCallback(const CefString& callbackId, const CefRefPtr<CefV8Value> result);
 
 	bool CallCppFunction(const CefString& function_name, const CefString& params, CefRefPtr<CefV8Value> callback, CefRefPtr<CefV8Value> rawdata);
 	void RemoveCallbackFuncWithFrame(CefRefPtr<CefFrame> frame);

--- a/common/webview_js_handler.h
+++ b/common/webview_js_handler.h
@@ -37,9 +37,7 @@ public:
 public:
 	static int  GetNextReqID();
 	bool StartRequest(int reqId, const CefString& strCmd, const CefString& strCallback, const CefString& strArgs);
-	bool EvaluateCallback(const CefString& callbackId, const CefString& result);
     bool EvaluateCallback(const CefString& callbackId, const JSValue& result);
-    bool EvaluateCallback(const CefString& callbackId, const CefRefPtr<CefV8Value> result);
 
 	bool CallCppFunction(const CefString& function_name, const CefString& params, CefRefPtr<CefV8Value> callback, CefRefPtr<CefV8Value> rawdata);
 	void RemoveCallbackFuncWithFrame(CefRefPtr<CefFrame> frame);

--- a/common/webview_js_handler.h
+++ b/common/webview_js_handler.h
@@ -13,7 +13,7 @@ static const char kEvaluateCallbackMessage[] = "EvaluateCallback";		 //js callba
 static const char kFocusedNodeChangedMessage[] = "FocusedNodeChanged";		 //elements that capture focus in web pages changed message
 
 struct JSValue {
-    enum class Type { STRING, INT, BOOL, DOUBLE, ARRAY, OBJECT, UNKNOWN } type;
+    enum class Type { STRING, INT, BOOL, DOUBLE, ARRAY, UNKNOWN } type;
 
     std::string stringValue;
     int intValue;

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -423,28 +423,22 @@ namespace webview_cef {
 			int browserId = int(webview_value_get_int(webview_value_get_list_value(values, 0)));
 			const auto code = webview_value_get_string(webview_value_get_list_value(values, 1));
 			m_handler->executeJavaScript(browserId, code, [=](CefRefPtr<CefValue> values){
-                printf("AJKAJKA");
                 WValue* retValue;
 
                 switch(values->GetType()) {
                     case VTYPE_BOOL:
-                        printf("VTYPE_BOOL");
                         retValue = webview_value_new_bool(values->GetBool());
                         break;
                     case VTYPE_DOUBLE:
-                        printf("VTYPE_DOUBLE");
                         retValue = webview_value_new_double(values->GetDouble());
                         break;
                     case VTYPE_INT:
-                        printf("VTYPE_INT");
                         retValue = webview_value_new_int(values->GetInt());
                         break;
                     case VTYPE_STRING:
-                        printf("VTYPE_STRING");
                         retValue = webview_value_new_string(values->GetString().ToString().c_str());
                         break;
                     default:
-                        printf("default");
                         break;
                 }
 				result(1, retValue);

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -425,6 +425,12 @@ namespace webview_cef {
 			m_handler->executeJavaScript(browserId, code, [=](CefRefPtr<CefValue> values){
                 WValue* retValue;
 
+                if (values == nullptr) {
+                    result(1, nullptr);
+                    webview_value_unref(retValue);
+                    return;
+                }
+
                 switch(values->GetType()) {
                     case VTYPE_BOOL:
                         retValue = webview_value_new_bool(values->GetBool());

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -422,8 +422,31 @@ namespace webview_cef {
 		else if(name.compare("evaluateJavascript") == 0){
 			int browserId = int(webview_value_get_int(webview_value_get_list_value(values, 0)));
 			const auto code = webview_value_get_string(webview_value_get_list_value(values, 1));
-			m_handler->executeJavaScript(browserId, code, [=](std::string values){
-				WValue* retValue = webview_value_new_string(values.c_str());
+			m_handler->executeJavaScript(browserId, code, [=](CefRefPtr<CefValue> values){
+                printf("AJKAJKA");
+                WValue* retValue;
+
+                switch(values->GetType()) {
+                    case VTYPE_BOOL:
+                        printf("VTYPE_BOOL");
+                        retValue = webview_value_new_bool(values->GetBool());
+                        break;
+                    case VTYPE_DOUBLE:
+                        printf("VTYPE_DOUBLE");
+                        retValue = webview_value_new_double(values->GetDouble());
+                        break;
+                    case VTYPE_INT:
+                        printf("VTYPE_INT");
+                        retValue = webview_value_new_int(values->GetInt());
+                        break;
+                    case VTYPE_STRING:
+                        printf("VTYPE_STRING");
+                        retValue = webview_value_new_string(values->GetString().ToString().c_str());
+                        break;
+                    default:
+                        printf("default");
+                        break;
+                }
 				result(1, retValue);
 				webview_value_unref(retValue);
 			});

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -438,9 +438,31 @@ namespace webview_cef {
                     case VTYPE_STRING:
                         retValue = webview_value_new_string(values->GetString().ToString().c_str());
                         break;
-                    default:
+                    case VTYPE_LIST:
+                        retValue = webview_value_new_list();
+                        CefRefPtr<CefListValue> list = values->GetList();
+                        
+                        if (list) {
+                            for (size_t i = 0; i < list->GetSize(); ++i) {
+                                CefValueType type = list->GetType(i);
+                                CefRefPtr<CefValue> listItem = list->GetValue(i);
+
+                                if (type == VTYPE_INT) {
+                                    webview_value_append(retValue, webview_value_new_int(listItem->GetInt()));
+                                } else if (type == VTYPE_BOOL) {
+                                    webview_value_append(retValue, webview_value_new_bool(listItem->GetBool()));
+                                } else if (type == VTYPE_STRING) {
+                                    webview_value_append(retValue, webview_value_new_string(listItem->GetString().ToString().c_str()));
+                                } else if (type == VTYPE_DOUBLE) {
+                                    webview_value_append(retValue, webview_value_new_double(listItem->GetDouble()));
+                                } else {
+                                    continue;
+                                }
+                            }
+                        }
                         break;
                 }
+
 				result(1, retValue);
 				webview_value_unref(retValue);
 			});

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -75,12 +75,15 @@ class _MyAppState extends State<MyApp> {
       onLoadStart: (controller, url) {
         print("onLoadStart => $url");
       },
-      onLoadEnd: (controller, url) {
+      onLoadEnd: (controller, url) async {
         print("onLoadEnd => $url");
+        var ret = await _controller.evaluateJavascript('window.returnHundred();');
+        print("[ReturnHundred] $ret");
       },
     ));
 
     await _controller.initialize(_textController.text);
+    _controller.openDevTools();
 
     // _controller2.setWebviewListener(WebviewEventsListener(
     //   onTitleChanged: (t) {},

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -75,13 +75,12 @@ class _MyAppState extends State<MyApp> {
       onLoadStart: (controller, url) {
         print("onLoadStart => $url");
       },
-      onLoadEnd: (controller, url) async {
+      onLoadEnd: (controller, url) {
         print("onLoadEnd => $url");
       },
     ));
 
     await _controller.initialize(_textController.text);
-    _controller.openDevTools();
 
     // _controller2.setWebviewListener(WebviewEventsListener(
     //   onTitleChanged: (t) {},

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -77,8 +77,6 @@ class _MyAppState extends State<MyApp> {
       },
       onLoadEnd: (controller, url) async {
         print("onLoadEnd => $url");
-        var ret = await _controller.evaluateJavascript('window.returnHundred();');
-        print("[ReturnHundred] $ret");
       },
     ));
 


### PR DESCRIPTION
Improve the `evaluateJavascript` method to accept int/double/bool/ArrayList as well as String as a response value.
The existing `evaluateJavascript` method receives the result value as shown below, which does not return data types other than String.
`CefString result = arguments[1]->GetStringValue();`
```c++
// webview_js_handler.cc
else if (name == "EvaluateCallback") {
	CefString callbackId = arguments[0]->GetStringValue();
        // Here!
	CefString result = arguments[1]->GetStringValue();
	if (!js_bridge_->EvaluateCallback(callbackId, result)) {
		std::ostringstream strStream;
		strStream << "Failed to callback:  " << callbackId.c_str() << ".";
		strStream.flush();
		
		exception = strStream.str();
	}
}
```

In this PR, we improved it to be able to return int / double / bool / ArrayList data types from JavaScript using `CefRefPtr<CefV8Value>`.
In addition, it now also returns null if the JavaScript method returns no value,
It seems to be able to act as the existing `executeJavaScript` method.

So you can work with the example below.
```dart
// return int javascript method
/* 
function returnIntMethod() {
   return 100;
} 
*/
var retVal_int = await _controller.evaluateJavascript(‘window.returnIntMethod();’);
// retVal_int -> 100


// return string javascript method
/*
function returnStringMethod() {
    return 'webView_CEF';
}
*/
var retVal_string = await _controller.evaluateJavascript(‘window.returnStringMethod();’);
// retVal_string -> 'webView_CEF'


// return boolean javascript method
/* 
function returnBooleanMethod() {
    return true;
}
*/
var retVal_bool = await _controller.evaluateJavascript(‘window.returnBooleanMethod();’);
// retVal_bool -> true


// return double javascript method
/*
function returnDoubleMethod() {
    return 0.123;
}
*/
var retVal_double = await _controller.evaluateJavascript(‘window.returnDoubleMethod();’);
// retVal_double -> 0.123


// return arrayList javascript method
/*
function returnArrayListMethod() {
    return [100, 'webView_CEF', true, 0.123];
}
*/
var retVal_array_list = await _controller.evaluateJavascript(‘window.returnArrayListMethod();’);
// retVal_array_list -> [100, 'webView_cef', true, 0.123]


// return null javascript method
/*
function returnNullMethod() {
    return;
}
*/
var retVal_null = await _controller.evaluateJavascript(‘window.returnNullMethod();’);
// retVal_null -> null
```

However, rather than just removing the `executeJavaScript` method right away, would you mind if we looked into it a bit more and submitted a PR to remove the `executeJavaScript` method?

Finally, we've fixed the indentation of the code.