### PR TITLE
fix: modified null check issue

### DIFF
--- a/lib/src/webview_inject_user_script.dart
+++ b/lib/src/webview_inject_user_script.dart
@@ -14,11 +14,11 @@ class InjectUserScripts {
     userScripts.add(script);
   }
 
-  List<UserScript>? retrieveLoadStartInjectScripts() {
+  List<UserScript> retrieveLoadStartInjectScripts() {
     return userScripts.where((e) => e.injectTime == ScriptInjectTime.LOAD_START).toList();
   }
 
-  List<UserScript>? retrieveLoadEndInjectScripts() {
+  List<UserScript> retrieveLoadEndInjectScripts() {
     return userScripts.where((e) => e.injectTime == ScriptInjectTime.LOAD_END).toList();
   }
 }

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -134,7 +134,7 @@ class WebviewManager extends ValueNotifier<bool> {
         int browserId = call.arguments["browserId"] as int;
         String urlId = call.arguments["urlId"] as String;
 
-        await _injectUserScriptIfNeeds(browserId, _injectUserScripts?.retrieveLoadStartInjectScripts());
+        await _injectUserScriptIfNeeds(browserId, _injectUserScripts?.retrieveLoadStartInjectScripts() ?? []);
 
         WebViewController controller =
         _webViews[browserId] as WebViewController;
@@ -144,7 +144,7 @@ class WebviewManager extends ValueNotifier<bool> {
         int browserId = call.arguments["browserId"] as int;
         String urlId = call.arguments["urlId"] as String;
 
-        await _injectUserScriptIfNeeds(browserId, _injectUserScripts?.retrieveLoadEndInjectScripts());
+        await _injectUserScriptIfNeeds(browserId, _injectUserScripts?.retrieveLoadEndInjectScripts() ?? []);
 
         WebViewController controller =
         _webViews[browserId] as WebViewController;
@@ -154,8 +154,8 @@ class WebviewManager extends ValueNotifier<bool> {
     }
   }
 
-  Future<void> _injectUserScriptIfNeeds(int browserId, List<UserScript>? scripts) async {
-    if (scripts == null) return;
+  Future<void> _injectUserScriptIfNeeds(int browserId, List<UserScript> scripts) async {
+    if (scripts.isEmpty) return;
 
     await _webViews[browserId]?.ready;
 


### PR DESCRIPTION
Improve null check logic when injecting UserScript.
If you tried to inject a script at Load_Start, but the retrieveLoadEndInjectScripts method in `webview_inject_user_script.dart` returned a non-null empty array, there was a possibility that the script would be injected at the wrong time.
To fix this, change it to check Empty, not null.