### PR TITLE
Auto setup Linux target - make manual target modifications obsolete

### DIFF
--- a/.github/workflows/test_linux_x64.yaml
+++ b/.github/workflows/test_linux_x64.yaml
@@ -1,4 +1,4 @@
-name: Test if the example app still builds on Linux x86
+name: Test if the example app still builds on Linux x64
 on:
   push:
     branches: ["main"]
@@ -9,7 +9,7 @@ on:
       - "linux/**"
       - "third/**"
       - "pubspec.yaml"
-      - ".github/workflows/test_linux_x86.yaml"
+      - ".github/workflows/test_linux_x64.yaml"
   pull_request:
     paths:
       - "common/**"
@@ -18,7 +18,7 @@ on:
       - "linux/**"
       - "third/**"
       - "pubspec.yaml"
-      - ".github/workflows/test_linux_x86.yaml"
+      - ".github/workflows/test_linux_x64.yaml"
 
 jobs:
   main:

--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ Then follow the below steps inside the `macos/` folder <b>of the cloned reposito
 
 ### Linux <img src="https://1000logos.net/wp-content/uploads/2017/03/LINUX-LOGO.png" width="16">
 
-This part of the content needs to be summarized. You can refer to the methods in the example first(Very similar to on the Windows). In addition, you need to modify the method of copying resources in the linux/CMakeLists.txt under your own project to be consistent with that in windows. Otherwise, the resource files cannot be copied properly under linux.
-![image](https://github.com/hlwhl/webview_cef/assets/49640121/dd03a510-2bc1-4c73-bf9c-ba4b5abee135)
+For Linux, just adding `webview_cef` to your `pubspec.yaml` (e.g. by running `flutter pub add webview_cef`) does the job.
 
 ## TODOs
 

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -11,6 +11,14 @@ set(PROJECT_NAME "webview_cef")
 project(${PROJECT_NAME} LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 17)
 
+# Auto setup Linux target
+execute_process(
+  COMMAND bash "${CMAKE_CURRENT_SOURCE_DIR}/target_modifier/modify_target.sh"
+  OUTPUT_VARIABLE patch_output
+)
+message(WARNING "${patch_output}")
+
+# Setup CEF
 include(${CMAKE_CURRENT_SOURCE_DIR}/../third/download.cmake)
 prepare_prebuilt_files(${CMAKE_CURRENT_SOURCE_DIR}/../third/cef)
 

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -104,14 +104,34 @@ add_definitions("-DGTK_DISABLE_DEPRECATED")
 # Set SUID permissions on the chrome-sandbox target.
 # SET_LINUX_SUID_PERMISSIONS("${CEF_TARGET}" "${CEF_TARGET_OUT_DIR}/chrome-sandbox")
 
+
+# Init INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV that contains the build dir of the application
+set(INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV "${PROJECT_BINARY_DIR}")
+get_filename_component(INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV "${INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV}" DIRECTORY)
+get_filename_component(INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV "${INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV}" DIRECTORY)
+set(INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV "${INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV}/bundle/lib")
+
+
 #set CEF binary and resource files which need to copy to the target output directory
 set(cef_library_list "")
 foreach(FILE ${CEF_BINARY_FILES})
   list(APPEND cef_library_list ${CEF_BINARY_DIR}/${FILE})
 endforeach()
-foreach(FILE ${CEF_RESOURCE_FILES})
 
-  list(APPEND cef_library_list ${CEF_RESOURCE_DIR}/${FILE})
+foreach(FILE ${CEF_RESOURCE_FILES})
+  # If ${FILE} is a directory (e.g. locales), install them directly.
+  # Avoids error with the Linux target CMakeList
+  if(IS_DIRECTORY ${CEF_RESOURCE_DIR}/${FILE})
+    file(GLOB LOCAL_FILES "${CEF_RESOURCE_DIR}/${FILE}/*")
+    foreach(LOCAL_FILE ${LOCAL_FILES})
+      install(FILES "${LOCAL_FILE}"
+              DESTINATION "${INSTALL_BUNDLE_APPLICATION_DIR_WEBVIEW_CEV}/${FILE}"
+              COMPONENT Runtime)
+    endforeach()
+  else()
+    # If ${FILE} is not a directory, treat it normally
+    list(APPEND cef_library_list ${CEF_RESOURCE_DIR}/${FILE})
+  endif()
 endforeach(FILE)
 #######################################cef end#######################################
 

--- a/linux/target_modifier/modify_target.sh
+++ b/linux/target_modifier/modify_target.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Will be something like /home/test/flutter_projects/example
+program_path="${PWD%%/build/linux/*}"
+
+# Will be the path of this script
+scriptdir=$(cd $(dirname $0); pwd -P)
+
+echo "Modifying target cc files..."
+
+bash $scriptdir/tools/import_webview_cef_header_my_application.sh "$program_path/linux/my_application.cc"
+bash $scriptdir/tools/add_key_release_event_to_my_application.sh "$program_path/linux/my_application.cc"
+bash $scriptdir/tools/add_key_press_event_to_my_application.sh "$program_path/linux/my_application.cc"
+
+bash $scriptdir/tools/import_webview_cef_header_main.sh "$program_path/linux/main.cc"
+bash $scriptdir/tools/add_webview_init_to_main.sh "$program_path/linux/main.cc"

--- a/linux/target_modifier/tools/add_key_press_event_to_my_application.sh
+++ b/linux/target_modifier/tools/add_key_press_event_to_my_application.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Add
+# g_signal_connect(view, \"key_press_event\", G_CALLBACK(processKeyEventForCEF), nullptr);
+# after
+# FlView* view = fl_view_new(project);
+# if not already added
+
+# Check if the correct number of arguments is passed
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <file-path>"
+  exit 1
+fi
+
+# Assign file path argument
+file="$1"
+
+# Check if the file exists
+if [ ! -f "$file" ]; then
+  echo "File not found: $file"
+  exit 1
+fi
+
+# Check if the line g_signal_connect exists in the file
+if grep -q '^[[:space:]]*g_signal_connect(view, "key_press_event", G_CALLBACK(processKeyEventForCEF), nullptr);' "$file"; then
+  echo "The line 'g_signal_connect(view, \"key_press_event\", G_CALLBACK(processKeyEventForCEF), nullptr);' already exists in the file."
+else
+  # Insert g_signal_connect after the first occurrence of FlView* view = fl_view_new(project);
+  awk '
+    /^[[:space:]]*FlView\* view = fl_view_new\(project\);/ {
+      print $0;
+      print "  g_signal_connect(view, \"key_press_event\", G_CALLBACK(processKeyEventForCEF), nullptr);";
+      next;
+    }
+    { print }
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+
+  echo "Added 'g_signal_connect(view, \"key_press_event\", G_CALLBACK(processKeyEventForCEF), nullptr);' after 'FlView* view = fl_view_new(project);'."
+fi

--- a/linux/target_modifier/tools/add_key_release_event_to_my_application.sh
+++ b/linux/target_modifier/tools/add_key_release_event_to_my_application.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Add
+# g_signal_connect(view, \"key_release_event\", G_CALLBACK(processKeyEventForCEF), nullptr);
+# after
+# FlView* view = fl_view_new(project);
+# if not already added
+
+# Check if the correct number of arguments is passed
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <file-path>"
+  exit 1
+fi
+
+# Assign file path argument
+file="$1"
+
+# Check if the file exists
+if [ ! -f "$file" ]; then
+  echo "File not found: $file"
+  exit 1
+fi
+
+# Check if the line g_signal_connect exists in the file
+if grep -q '^[[:space:]]*g_signal_connect(view, "key_release_event", G_CALLBACK(processKeyEventForCEF), nullptr);' "$file"; then
+  echo "The line 'g_signal_connect(view, \"key_release_event\", G_CALLBACK(processKeyEventForCEF), nullptr);' already exists in the file."
+else
+  # Insert g_signal_connect after the first occurrence of FlView* view = fl_view_new(project);
+  awk '
+    /^[[:space:]]*FlView\* view = fl_view_new\(project\);/ {
+      print $0;
+      print "  g_signal_connect(view, \"key_release_event\", G_CALLBACK(processKeyEventForCEF), nullptr);";
+      next;
+    }
+    { print }
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+
+  echo "Added 'g_signal_connect(view, \"key_release_event\", G_CALLBACK(processKeyEventForCEF), nullptr);' after 'FlView* view = fl_view_new(project);'."
+fi

--- a/linux/target_modifier/tools/add_webview_init_to_main.sh
+++ b/linux/target_modifier/tools/add_webview_init_to_main.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Adds
+# initCEFProcesses(argc, argv);
+# to main function of main.cc
+
+# Check if the correct number of arguments is passed
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <file-path>"
+  exit 1
+fi
+
+# Assign file path argument
+file="$1"
+
+# Check if the file exists
+if [ ! -f "$file" ]; then
+  echo "File not found: $file"
+  exit 1
+fi
+
+# Check if the line initCEFProcesses(argc, argv); already exists in the file
+if grep -q '^[[:space:]]*initCEFProcesses(argc, argv);' "$file"; then
+  echo "The line 'initCEFProcesses(argc, argv);' already exists in the file."
+else
+  # Insert initCEFProcesses(argc, argv); before the first line starting with g_autoptr(
+  awk '
+    /^[[:space:]]*g_autoptr/ {
+      print "  initCEFProcesses(argc, argv);";
+    }
+    { print }
+  ' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+
+  echo "Added 'initCEFProcesses(argc, argv);' before the first line starting with 'g_autoptr('."
+fi

--- a/linux/target_modifier/tools/import_webview_cef_header_main.sh
+++ b/linux/target_modifier/tools/import_webview_cef_header_main.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Adds '#include <webview_cef/webview_cef_plugin.h>' at the top of the file
+
+# Check if the correct number of arguments is passed
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <file-path>"
+  exit 1
+fi
+
+# Assign file path argument
+file="$1"
+
+# Check if the file exists
+if [ ! -f "$file" ]; then
+  echo "File not found: $file"
+  exit 1
+fi
+
+# Check if the line already exists in the file
+if grep -q '#include <webview_cef/webview_cef_plugin.h>' "$file"; then
+  echo "The line '#include <webview_cef/webview_cef_plugin.h>' already exists in the file."
+else
+  # Add the line at the top of the file
+  (echo "#include <webview_cef/webview_cef_plugin.h>"; cat "$file") > "$file.tmp" && mv "$file.tmp" "$file"
+  echo "Added '#include <webview_cef/webview_cef_plugin.h>' at the top of the file."
+fi

--- a/linux/target_modifier/tools/import_webview_cef_header_my_application.sh
+++ b/linux/target_modifier/tools/import_webview_cef_header_my_application.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Adds the line
+# '#include <webview_cef/webview_cef_plugin.h>'
+# after the line
+# '#include "flutter/generated_plugin_registrant.h"'
+# if '#include <webview_cef/webview_cef_plugin.h>' is missing
+
+# Check if the correct number of arguments is passed
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <file-path>"
+  exit 1
+fi
+
+# Assign file path argument
+file="$1"
+
+# Check if the file exists
+if [ ! -f "$file" ]; then
+  echo "File not found: $file"
+  exit 1
+fi
+
+# Check if the line already exists in the file
+if grep -q '#include <webview_cef/webview_cef_plugin.h>' "$file"; then
+  echo "The line '#include <webview_cef/webview_cef_plugin.h>' already exists in the file."
+  exit 0
+fi
+
+# Iterate through the file and look for the line "#include \"flutter/generated_plugin_registrant.h\""
+awk '
+  /#include "flutter\/generated_plugin_registrant.h"/ {
+    print;
+    print "#include <webview_cef/webview_cef_plugin.h>"
+    next
+  }
+  { print }
+' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+
+echo "Added '#include <webview_cef/webview_cef_plugin.h>' after '#include \"flutter/generated_plugin_registrant.h\"'"


### PR DESCRIPTION
Right now, you need to manually edit files in the Linux target. This PR resolves that so that you just add webview_cef to your pubspec and are good to go.

...and rename the build test workflow.