### PR TITLE
chore: bump pubspec version to 0.5.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_cef
 description: Flutter Desktop Webview backed by CEF (Chromium Embedded Framework).
-version: 0.2.3
+version: 0.5.0
 homepage: https://github.com/hlwhl/webview_cef
 repository: https://github.com/hlwhl/webview_cef
 


### PR DESCRIPTION
Syncs `pubspec.yaml` to **0.5.0** to match the CHANGELOG (already bumped in b68c360) and unblock the release.

The pub.dev automated-publishing workflow (`.github/workflows/publish.yaml`) triggers on `v[0-9]+.[0-9]+.[0-9]+*` tags and uses the `v{{version}}` pattern, which requires the **tag** (`v0.5.0`) and the **pubspec version** to agree. `pubspec.yaml` was still at `0.2.3`, so a `v0.5.0` tag would be rejected.

After merge, releasing is:
```bash
git checkout main && git pull
git tag v0.5.0
git push origin v0.5.0   # triggers publish.yaml -> pub.dev
```

(Requires pub.dev automated publishing to be enabled for the package: Admin → Automated publishing → repo `hlwhl/webview_cef`, tag pattern `v{{version}}`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)