### PR TITLE
0.5.1: fix stale version reference in Chinese README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.1
+- Docs: fixed a stale version reference in the Chinese README (the upgrade-guide intro still said 0.2.3 instead of 0.5.0). No code changes.
+
 ## 0.5.0
 - **Upgrading from ≤ 0.2.2?** This release has breaking changes (toolchain, removed API, platform minimums, Windows `initCEFProcesses` signature). See the "Upgrading from ≤ 0.2.2" section in the README.
 - Adapted to the latest stable Flutter (tested on 3.44.x).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@
 
 ## 从 ≤ 0.2.2 升级
 
-0.2.3 是一次大版本升级（Flutter 3.44 + CEF 149），在所有平台上都有破坏性变更。若你从旧版本升级，请按以下步骤操作：
+0.5.0 是一次大版本升级（Flutter 3.44 + CEF 149），在所有平台上都有破坏性变更。若你从旧版本升级，请按以下步骤操作：
 
 - **工具链** —— 升级到 Flutter **≥ 3.27.0** / Dart **≥ 3.6.0**（原为 2.5.0 / 2.17.1）。原生构建现在需要 **C++20**（CEF 149）；请确保你的工程没有把插件 target 强制设为更低的 C++ 标准。
 - **移除的 Dart API** —— `WebviewCefPlatform`、`MethodChannelWebviewCef`、`getPlatformVersion()` 已移除（同时移除了 `plugin_platform_interface` 依赖）。它们本就不是对外 API，且无替代（`getPlatformVersion` 仅返回演示值）。请只 import `package:webview_cef/webview_cef.dart`，使用 `WebviewManager` / `WebViewController`。

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_cef
 description: Flutter Desktop Webview backed by CEF (Chromium Embedded Framework).
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/hlwhl/webview_cef
 repository: https://github.com/hlwhl/webview_cef
 


### PR DESCRIPTION
Docs-only patch release.

- `README.zh-CN.md` upgrade-guide intro still said **0.2.3**; the English README was already updated to 0.5.0 — sync the Chinese one.
- Bump `pubspec.yaml` 0.5.0 → **0.5.1** and add a CHANGELOG entry.

After merge, release with:
```bash
git checkout main && git pull
git tag v0.5.1
git push origin v0.5.1   # triggers publish.yaml -> pub.dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)