### PR TITLE
Fix null-safe map literals

### DIFF
--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -16,11 +16,11 @@ class WebviewManager extends ValueNotifier<bool> {
 
   final MethodChannel pluginChannel = const MethodChannel("webview_cef");
 
-  final Map<int, WebViewController> _webViews = <int, WebViewController>{};
-  final Map<int, InjectUserScripts?> _injectUserScripts = <int, InjectUserScripts>{};
+  final _webViews = <int, WebViewController>{};
+  final _injectUserScripts = <int, InjectUserScripts?>{};
 
-  final Map<int, WebViewController> _tempWebViews = <int, WebViewController>{};
-  final Map<int, InjectUserScripts?> _tempInjectUserScripts = <int, InjectUserScripts>{};
+  final _tempWebViews = <int, WebViewController>{};
+  final _tempInjectUserScripts = <int, InjectUserScripts?>{};
 
   int nextIndex = 1;
 


### PR DESCRIPTION
Hi!
Thanks a lot for the latest improvements!
Unfortunately, the latest release gives me an exception like this:
```
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following _TypeError was thrown building KeyedSubtree-[GlobalKey#7d331]:
type 'Null' is not a subtype of type 'InjectUserScripts' of 'value'

The relevant error-causing widget was:
  Scaffold
  Scaffold:file:///home/test/example/lib/main.dart:29:18

When the exception was thrown, this was the stack:
#0      _LinkedHashMapMixin.[]= (dart:_compact_hash:642:30)
#1      WebviewManager.createWebView (package:webview_cef/src/webview_manager.dart:37:27)
...
#3      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:5950:55)
...
#4      ComponentElement.mount (package:flutter/src/widgets/framework.dart:5793:5)
...     Normal element mounting (25 frames)
#29     Element.inflateWidget (package:flutter/src/widgets/framework.dart:4587:20)
#30     MultiChildRenderObjectElement.inflateWidget (package:flutter/src/widgets/framework.dart:7264:36)
#31     MultiChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:7279:32)
...     Normal element mounting (342 frames)
#373    Element.inflateWidget (package:flutter/src/widgets/framework.dart:4587:20)
#374    MultiChildRenderObjectElement.inflateWidget (package:flutter/src/widgets/framework.dart:7264:36)
#375    MultiChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:7279:32)
...     Normal element mounting (535 frames)
#910    Element.inflateWidget (package:flutter/src/widgets/framework.dart:4587:20)
#911    Element.updateChild (package:flutter/src/widgets/framework.dart:4059:18)
#912    _RawViewElement._updateChild (package:flutter/src/widgets/view.dart:481:16)
#913    _RawViewElement.mount (package:flutter/src/widgets/view.dart:504:5)
...     Normal element mounting (15 frames)
#928    Element.inflateWidget (package:flutter/src/widgets/framework.dart:4587:20)
#929    Element.updateChild (package:flutter/src/widgets/framework.dart:4059:18)
#930    RootElement._rebuild (package:flutter/src/widgets/binding.dart:2091:16)
#931    RootElement.mount (package:flutter/src/widgets/binding.dart:2060:5)
#932    RootWidget.attach.<anonymous closure> (package:flutter/src/widgets/binding.dart:2013:18)
#933    BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:3101:19)
#934    RootWidget.attach (package:flutter/src/widgets/binding.dart:2012:13)
#935    WidgetsBinding.attachToBuildOwner (package:flutter/src/widgets/binding.dart:1688:27)
#936    WidgetsBinding.attachRootWidget (package:flutter/src/widgets/binding.dart:1673:5)
#937    WidgetsBinding.scheduleAttachRootWidget.<anonymous closure> (package:flutter/src/widgets/binding.dart:1659:7)
#941    _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
(elided 3 frames from class _Timer and dart:async-patch)
```

This PR fixes it (already tested it).  
  
Explanation:
`Map<int, InjectUserScripts?>` and ` = <int, InjectUserScripts>{};` collide (at init, we don't allow `null` anymore). But later, we try to set `null`. Since we use modern Dart (3+), we can remove `= ...` completely.