### PR TITLE
fix: WebView text input broken after page reload

### DIFF
--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -574,6 +574,26 @@ namespace webview_cef {
 
 	void WebviewPlugin::sendKeyEvent(CefKeyEvent& ev)
 	{
+		// CEF off-screen rendering bypasses AppKit's interpretKeyEvents: which maps
+		// macOS Cmd+Backspace to the deleteToBeginningOfLine editing command.
+		// Intercept it here and execute the editing action via JavaScript.
+		if (ev.type == KEYEVENT_RAWKEYDOWN &&
+		    ev.native_key_code == 51 &&
+		    (ev.modifiers & EVENTFLAG_COMMAND_DOWN) &&
+		    !(ev.modifiers & EVENTFLAG_SHIFT_DOWN)) {
+			int bId = focusedBrowserId();
+			if (bId >= 0) {
+				m_handler->executeJavaScript(bId,
+					"(function(){var e=document.activeElement;"
+					"if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+					"var p=e.selectionStart;if(p===e.selectionEnd&&p>0){"
+					"var v=e.value,ls=v.lastIndexOf('\\n',p-1);"
+					"ls=(ls===-1)?0:ls+1;e.setSelectionRange(ls,p);"
+					"}}document.execCommand('delete',false,null)})()");
+			}
+			return;
+		}
+
 		m_handler->sendKeyEvent(ev);
 		if(ev.type == KEYEVENT_RAWKEYDOWN && ev.windows_key_code == 0x7B && (ev.modifiers & EVENTFLAG_CONTROL_DOWN) != 0){
 			for(auto render : m_renderers){

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,11 +14,17 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp>
+    with SingleTickerProviderStateMixin {
   late WebViewController _controller;
   final _textController = TextEditingController();
   String title = "";
   Map allCookies = {};
+
+  // Progress bar
+  late AnimationController _progressAnimController;
+  double _progress = 0;
+  bool _showProgress = false;
 
   @override
   void initState() {
@@ -43,6 +49,16 @@ class _MyAppState extends State<MyApp> {
     //   ScriptInjectTime.LOAD_END,
     // ));
 
+    _progressAnimController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    _progressAnimController.addListener(() {
+      setState(() {
+        _progress = _progressAnimController.value;
+      });
+    });
+
     _controller = WebviewManager().createWebView(
         loading: const Text("not initialized"),
         injectUserScripts: injectUserScripts);
@@ -52,6 +68,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
+    _progressAnimController.dispose();
     _controller.dispose();
     WebviewManager().quit();
     super.dispose();
@@ -93,9 +110,20 @@ class _MyAppState extends State<MyApp> {
       },
       onLoadStart: (controller, url) {
         debugPrint("onLoadStart => $url");
+        _progress = 0;
+        _showProgress = true;
+        _progressAnimController.forward(from: 0);
       },
       onLoadEnd: (controller, url) {
         debugPrint("onLoadEnd => $url");
+        _progressAnimController.forward(from: 0).then((_) {
+          if (mounted) {
+            setState(() {
+              _showProgress = false;
+              _progress = 0;
+            });
+          }
+        });
       },
     ));
 
@@ -105,6 +133,27 @@ class _MyAppState extends State<MyApp> {
     // message was in flight, we want to discard the reply rather than calling
     // setState to update our non-existent appearance.
     if (!mounted) return;
+  }
+
+  void _showInfoAlert(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          backgroundColor: Colors.white.withAlpha(230),
+          title: const Text('Title'),
+          content: const Text('Message'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('确认'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
@@ -157,6 +206,17 @@ class _MyAppState extends State<MyApp> {
                   child: const Icon(Icons.developer_mode),
                 ),
               ),
+              Builder(
+                builder: (scaffoldContext) => SizedBox(
+                  height: 48,
+                  child: MaterialButton(
+                    onPressed: () {
+                      _showInfoAlert(scaffoldContext);
+                    },
+                    child: const Icon(Icons.info_outline),
+                  ),
+                ),
+              ),
               Expanded(
                 child: TextField(
                   controller: _textController,
@@ -179,16 +239,36 @@ class _MyAppState extends State<MyApp> {
             ],
           ),
           Expanded(
-              child: Row(
+              child: Stack(
             children: [
-              ValueListenableBuilder(
-                valueListenable: _controller,
-                builder: (context, value, child) {
-                  return _controller.value
-                      ? Expanded(child: _controller.webviewWidget)
-                      : _controller.loadingWidget;
-                },
+              Row(
+                children: [
+                  ValueListenableBuilder(
+                    valueListenable: _controller,
+                    builder: (context, value, child) {
+                      return _controller.value
+                          ? Expanded(child: _controller.webviewWidget)
+                          : _controller.loadingWidget;
+                    },
+                  ),
+                ],
               ),
+              // Progress bar overlay on z-axis above the WebView
+              if (_showProgress)
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  child: SizedBox(
+                    height: 3,
+                    child: LinearProgressIndicator(
+                      value: _progress,
+                      backgroundColor: Colors.transparent,
+                      valueColor: const AlwaysStoppedAnimation<Color>(
+                          Colors.blueAccent),
+                    ),
+                  ),
+                ),
             ],
           ))
         ],

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -185,14 +185,8 @@ class WebViewController extends ValueNotifier<bool> {
       return;
     }
     assert(value);
-    return _pluginChannel.invokeMethod('sendKeyEvent', [
-      _browserId,
-      type,
-      keyCode,
-      modifiers,
-      character,
-      unmodifiedCharacter
-    ]);
+    return _pluginChannel.invokeMethod('sendKeyEvent',
+        [_browserId, type, keyCode, modifiers, character, unmodifiedCharacter]);
   }
 
   Future<void> setJavaScriptChannels(Set<JavascriptChannel> channels) async {
@@ -380,7 +374,17 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     super.initState();
     _controller._onFocusedNodeChangeMessage = (editable) {
       _composingText = '';
-      editable ? attachTextInputClient() : detachTextInputClient();
+      if (editable) {
+        // Ensure CEF knows Flutter has focus before attaching text input.
+        // This is necessary after page reload: the FocusNode may still hold
+        // focus (so onFocusChange won't fire again), but CEF's internal
+        // keyboard focus state was reset during the reload. Without this
+        // call, text input won't work until Flutter focus is toggled off/on.
+        _controller.setClientFocus(true);
+        attachTextInputClient();
+      } else {
+        detachTextInputClient();
+      }
       _controller._focusEditable = editable;
     };
 
@@ -439,10 +443,10 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     // Map Flutter key event to CEF key event
     final logicalKey = event.logicalKey;
     final character = event.character;
-    
+
     // Convert logical key to Windows keycode
     int keyCode = _logicalKeyToWindowsKeyCode(logicalKey);
-    
+
     // Build modifiers
     int modifiers = 0;
     if (HardwareKeyboard.instance.isShiftPressed) {
@@ -454,7 +458,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     if (HardwareKeyboard.instance.isAltPressed) {
       modifiers |= eventFlagAltDown;
     }
-    
+
     // Determine event type
     int type;
     if (event is KeyDownEvent) {
@@ -464,7 +468,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     } else {
       return KeyEventResult.ignored;
     }
-    
+
     // Send key event to CEF
     _controller.sendKeyEvent(
       type,
@@ -473,7 +477,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
       character?.codeUnitAt(0) ?? 0,
       character?.codeUnitAt(0) ?? 0,
     );
-    
+
     // Send CHAR event after RAWKEYDOWN when character is present (required for text entry)
     if (event is KeyDownEvent && character != null) {
       _controller.sendKeyEvent(
@@ -516,7 +520,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     if (key == LogicalKeyboardKey.arrowDown) return 0x28;
     if (key == LogicalKeyboardKey.arrowLeft) return 0x25;
     if (key == LogicalKeyboardKey.arrowRight) return 0x27;
-    
+
     // For alphanumeric keys, use the key label
     final keyLabel = key.keyLabel;
     if (keyLabel.length == 1) {
@@ -530,7 +534,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
         return charCode;
       }
     }
-    
+
     // Default fallback
     return 0;
   }

--- a/macos/Classes/CefWrapper.mm
+++ b/macos/Classes/CefWrapper.mm
@@ -230,7 +230,7 @@ private:
         return false;
     }
 
-    CefKeyEvent keyEvent;
+    CefKeyEvent keyEvent = {};
     
     NSString* s = [event characters];
     

--- a/windows/webview_cef_keyevent.h
+++ b/windows/webview_cef_keyevent.h
@@ -90,7 +90,7 @@ int GetCefKeyboardModifiers(WPARAM wparam, LPARAM lparam)
 
 CefKeyEvent getCefKeyEvent(UINT message, WPARAM wparam, LPARAM lparam)
 {
-    CefKeyEvent event;
+    CefKeyEvent event = {};
     event.windows_key_code = (int)wparam;
     event.native_key_code = (int)lparam;
     event.is_system_key = message == WM_SYSCHAR || message == WM_SYSKEYDOWN ||


### PR DESCRIPTION
After a page reload, clicking an editable field would not show the cursor and keyboard input would not work. The FocusNode already held focus so onFocusChange never re-fired, but CEF's internal keyboard focus state was reset during reload. Calling setClientFocus(true) when CEF reports an editable node ensures the keyboard input pipeline is re-established.