### PR TITLE
Fix keyboard shortcut

### DIFF
--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -31,22 +31,10 @@ jobs:
           channel: stable
       - name: Install build tools
         run: brew install ninja cmake
-      # macOS uses CocoaPods (not third/download.cmake), so the CEF framework and
-      # libcef_dll_wrapper must be placed into macos/third/cef manually.
-      # Keep CEF_VERSION in sync with third/download.cmake.
-      - name: Download CEF and build libcef_dll_wrapper
-        run: |
-          set -eo pipefail
-          CEF_VERSION="149.0.4+g2f1bfd8+chromium-149.0.7827.156"
-          NAME="cef_binary_${CEF_VERSION}_macosarm64"
-          URL_NAME=$(printf '%s' "$NAME" | sed 's/+/%2B/g')
-          curl -L -o cef.tar.bz2 "https://cef-builds.spotifycdn.com/${URL_NAME}.tar.bz2"
-          tar -xjf cef.tar.bz2
-          cmake -S "$NAME" -B "$NAME/build" -G Ninja -DPROJECT_ARCH=arm64 -DCMAKE_BUILD_TYPE=Release
-          cmake --build "$NAME/build" --target libcef_dll_wrapper
-          mkdir -p macos/third/cef
-          cp -R "$NAME/Release/Chromium Embedded Framework.framework" macos/third/cef/
-          cp "$NAME/build/libcef_dll_wrapper/libcef_dll_wrapper.a" macos/third/cef/
+      # CEF is downloaded and built by macos/scripts/download_cef.sh, which is
+      # invoked automatically via pod install (podspec prepare_command). It
+      # produces a universal (arm64 + x86_64) CEF by default — no manual steps
+      # needed.
       - run: flutter --version
       - name: Analyze plugin
         run: flutter analyze

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ app.*.map.json
 
 /macos/third/cef/Chromium Embedded Framework.framework
 /macos/third/cef/libcef_dll_wrapper.a
+
+# CEF prebuilt tarballs are too large for git (~300MB each). Place them
+# manually in cef_tar/ for offline builds — see cef_tar/README.md.
+/cef_tar/*.tar.bz2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with code in this repository.
+
+## Project Overview
+
+`webview_cef` is a Flutter plugin that embeds CEF (Chromium Embedded Framework) to provide WebView capabilities on macOS, Windows, Linux, and eLinux.
+
+## Guidelines
+
+### 1. Documentation Language
+
+All documentation under the `docs/` directory must be written in **Chinese**. This includes new files and updates to existing files.
+
+### 2. Git Commit Policy
+
+**Never auto-commit code.** Only commit when the user explicitly commands it (e.g., "提交代码", "commit", "提交暂存区"). Do not commit proactively after completing a task.
+
+### 3. Code Comments
+
+All code comments (in Dart, C++, ObjC, etc.) must be written in **English**. Maintain consistency with the existing codebase style.
+
+### 4. Commit Workflow
+
+When the user asks to commit code:
+1. **First**, review the staged changes and synchronize the `docs/` directory accordingly — update existing documentation or add new files to reflect the changes being committed.
+2. **Then**, stage the documentation updates together with the code changes and commit them as a single unit.

--- a/cef_tar/README.md
+++ b/cef_tar/README.md
@@ -1,0 +1,53 @@
+# CEF Prebuilt Tarballs
+
+此目录用于放置 CEF 官方预编译包，加速 `pod install` 中的下载过程。
+
+## 为什么需要？
+
+`pod install` 时会执行 `download_cef.sh`，默认需要从 Spotify CDN 下载两个架构的 CEF 包（共约 560MB）。国内网络环境下 CDN 下载速度可能很慢（数十分钟），将 tarball 预先放置到此目录后，脚本会自动跳过下载，直接使用本地文件，整个过程只需数秒。
+
+## 如何获取？
+
+### 方式一：执行下载脚本（推荐）
+
+```bash
+bash cef_tar/download_cef_tars.sh
+```
+
+脚本会自动读取 `third/download.cmake` 中的版本号，下载对应版本的 arm64 和 x86_64 两个 tarball。已存在的文件会自动跳过。
+
+### 方式二：手动下载
+
+从 Spotify CDN 下载当前版本：
+
+```bash
+# arm64（Apple Silicon）
+curl -L -o cef_tar/cef_binary_149.0.4+g2f1bfd8+chromium-149.0.7827.156_macosarm64.tar.bz2 \
+  "https://cef-builds.spotifycdn.com/cef_binary_149.0.4%2Bg2f1bfd8%2Bchromium-149.0.7827.156_macosarm64.tar.bz2"
+
+# x86_64（Intel）
+curl -L -o cef_tar/cef_binary_149.0.4+g2f1bfd8+chromium-149.0.7827.156_macosx64.tar.bz2 \
+  "https://cef-builds.spotifycdn.com/cef_binary_149.0.4%2Bg2f1bfd8%2Bchromium-149.0.7827.156_macosx64.tar.bz2"
+```
+
+也可以在浏览器中直接打开上述 URL 下载，然后手动移动到 `cef_tar/` 目录下。
+
+> **注意**：如果 CEF 版本升级（`third/download.cmake` 中的 `CEF_VERSION` 发生变化），需要下载对应新版本的 tarball，旧版本不会被使用。
+
+## 放置后效果
+
+下次执行 `pod install` 时，日志会显示：
+
+```
+==> Using local cef_binary_..._macosarm64.tar.bz2 (arm64) from cef_tar/
+```
+
+而非：
+
+```
+==> Downloading cef_binary_..._macosarm64.tar.bz2 (arm64)
+```
+
+## 文件不会被提交到 Git
+
+此目录下的 `*.tar.bz2` 已通过 `.gitignore` 排除，不会被提交到版本管理。

--- a/cef_tar/download_cef_tars.sh
+++ b/cef_tar/download_cef_tars.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Download CEF "Standard Distribution" tarballs into cef_tar/ for offline builds.
+#
+# By default pod install downloads CEF from Spotify CDN, which can be very slow
+# on some networks. Pre-downloading the tarballs with this script and placing
+# them in cef_tar/ lets download_cef.sh skip the CDN step entirely.
+#
+# Usage:
+#   bash cef_tar/download_cef_tars.sh          # download both architectures
+#
+# The CEF version is read from third/download.cmake (single source of truth).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+DOWNLOAD_CMAKE="${REPO_ROOT}/third/download.cmake"
+[ -f "${DOWNLOAD_CMAKE}" ] || { echo "error: cannot find ${DOWNLOAD_CMAKE}" >&2; exit 1; }
+
+CEF_VERSION="$(sed -n 's/^[[:space:]]*set(CEF_VERSION[[:space:]]*"\(.*\)").*/\1/p' "${DOWNLOAD_CMAKE}" | head -1)"
+[ -n "${CEF_VERSION}" ] || { echo "error: could not parse CEF_VERSION from ${DOWNLOAD_CMAKE}" >&2; exit 1; }
+
+CDN="https://cef-builds.spotifycdn.com"
+ARCHES=("arm64:macosarm64" "x86_64:macosx64")
+
+echo "CEF version: ${CEF_VERSION}"
+echo "Target dir:  ${SCRIPT_DIR}"
+echo ""
+
+for entry in "${ARCHES[@]}"; do
+  arch="${entry%%:*}"
+  cef_arch="${entry##*:}"
+  pkg="cef_binary_${CEF_VERSION}_${cef_arch}"
+  tarball="${SCRIPT_DIR}/${pkg}.tar.bz2"
+  url="${CDN}/$(printf '%s' "${pkg}.tar.bz2" | sed 's/+/%2B/g')"
+
+  if [ -f "${tarball}" ]; then
+    echo "==> ${pkg}.tar.bz2 already exists, skipping."
+    continue
+  fi
+
+  echo "==> Downloading ${pkg}.tar.bz2 (${arch})..."
+  curl -L --fail --connect-timeout 30 --max-time 3600 \
+       --retry 3 --retry-delay 5 \
+       -C - -o "${tarball}" "${url}"
+  echo "    Done."
+done
+
+echo ""
+echo "All tarballs ready. pod install will now use them directly."

--- a/common/webview_app.cc
+++ b/common/webview_app.cc
@@ -232,89 +232,143 @@ void WebviewApp::SetUnSafelyTreatInsecureOriginAsSecure(const CefString &strFilt
 //   <any>                       — Proxy auto-creates {postMessage} for any name
 void WebviewApp::OnWebKitInitialized()
 {
-    //inject js function for jssdk
+    // Register the V8 extension that wires the JS ↔ C++ bridge.
+    // The JS code below is injected into every V8 context before any page
+    // script runs, so channels ($cef.Print, etc.) are available immediately.
     std::string extensionCode = R"(
-			var $cef = {};
-			var clientSdk = {};
-			(() => {
-				clientSdk.jsCmd = (functionName, arg1, arg2, arg3) => {
-					if (typeof arg1 === 'function') {
-						native function jsCmd(functionName, arg1);
-						return jsCmd(functionName, arg1);
-					} 
-					else if	 (typeof arg2 === 'function') {
-                        jsonString = arg1;
-                        if	(typeof arg1 !== 'string'){
-						    jsonString = JSON.stringify(arg1);
-                        }
-						native function jsCmd(functionName, jsonString, arg2);
-						return jsCmd(functionName, jsonString, arg2);
-					}
-					else if	 (typeof arg3 === 'function') {
-                        jsonString = arg1;
-                        if	(typeof arg1 !== 'string'){
-						    jsonString = JSON.stringify(arg1);
-                        }
-						native function jsCmd(functionName, jsonString, arg2, arg3);
-						return jsCmd(functionName, jsonString, arg2, arg3);
-					}else {
+        var $cef = {};
+        var clientSdk = {};
 
-					}
-				};
-
-                $cef.JavaScriptChannel = (n,e,r) => {
-                    var a; 
-                    null == r ? a = '' : (a = '_' + new Date + (1e3 + Math.floor(8999 * Math.random())), window[a] = function (n, e) { 
-                        return function () { 
-                            try {
-                                e && e.call && e.call(null, arguments[1]) 
-                            } finally {
-                                delete window[n]
-                            } 
-                        } 
-                    }(a, r)); 
-                    try {
-                        $cef.StartRequest($cef.GetNextReqID(), n, a, JSON.stringify(e || {}), '') 
-                    } catch (l) {
-                        console.log('messeage send')
+        (() => {
+            // ── clientSdk.jsCmd ──────────────────────────────────────────
+            // Cross-process RPC: calls a C++ function by name with optional
+            // parameters and a callback. Used by older SDK integrations.
+            // Overloads are resolved by which argument position holds the
+            // callback function:
+            //   jsCmd(name, callback)
+            //   jsCmd(name, jsonString, callback)
+            //   jsCmd(name, jsonString, rawdata, callback)
+            clientSdk.jsCmd = (functionName, arg1, arg2, arg3) => {
+                if (typeof arg1 === 'function') {
+                    native function jsCmd(functionName, arg1);
+                    return jsCmd(functionName, arg1);
+                }
+                else if (typeof arg2 === 'function') {
+                    jsonString = arg1;
+                    if (typeof arg1 !== 'string') {
+                        jsonString = JSON.stringify(arg1);
                     }
+                    native function jsCmd(functionName, jsonString, arg2);
+                    return jsCmd(functionName, jsonString, arg2);
+                }
+                else if (typeof arg3 === 'function') {
+                    jsonString = arg1;
+                    if (typeof arg1 !== 'string') {
+                        jsonString = JSON.stringify(arg1);
+                    }
+                    native function jsCmd(functionName, jsonString, arg2, arg3);
+                    return jsCmd(functionName, jsonString, arg2, arg3);
+                }
+            };
+
+            // ── $cef.JavaScriptChannel(n, e, r) ──────────────────────────
+            // Core channel dispatcher. Called by Proxy-generated channel
+            // objects (e.g. $cef.Print.postMessage).
+            //   n — channel name (e.g. "Print")
+            //   e — message payload (string or object, JSON-stringified)
+            //   r — optional callback function(error, result)
+            //
+            // When a callback is provided, it is wrapped in a uniquely-named
+            // window function so the browser process can call it back later
+            // via ExecuteJavaScript. The wrapper self-cleans by deleting
+            // itself from window after the callback fires.
+            $cef.JavaScriptChannel = (n, e, r) => {
+                var callbackName;
+                if (r == null) {
+                    callbackName = '';
+                } else {
+                    callbackName = '_' + new Date
+                        + (1e3 + Math.floor(8999 * Math.random()));
+                    window[callbackName] = (function (name, fn) {
+                        return function () {
+                            try {
+                                fn && fn.call && fn.call(null, arguments[1]);
+                            } finally {
+                                delete window[name];
+                            }
+                        };
+                    })(callbackName, r);
                 }
 
-                $cef.EvaluateCallback = (nReqID, result) => {
-                    native function EvaluateCallback();
-                    EvaluateCallback(nReqID, result);
+                try {
+                    $cef.StartRequest(
+                        $cef.GetNextReqID(),
+                        n,
+                        callbackName,
+                        JSON.stringify(e || {}),
+                        ''
+                    );
+                } catch (ex) {
+                    console.log(
+                        'JavaScriptChannel: failed to send for "'
+                        + n + '"', ex
+                    );
                 }
+            };
 
-				$cef.StartRequest  = (nReqID, strCmd, strCallBack, strArgs, strLog) => {
-					native function StartRequest();
-					StartRequest(nReqID, strCmd, strCallBack, strArgs, strLog);
-				};
-				$cef.GetNextReqID  = () => {
-				  native function GetNextReqID();
-				  return GetNextReqID();
-				};
+            // ── $cef.EvaluateCallback(id, val) ───────────────────────────
+            // Callback channel for evaluateJavascript (Dart → JS → Dart).
+            // The browser process wraps the JS expression in a self-invoking
+            // function whose return value calls back through this native
+            // binding → CefJSBridge::EvaluateCallback → PID_BROWSER.
+            $cef.EvaluateCallback = (nReqID, result) => {
+                native function EvaluateCallback();
+                EvaluateCallback(nReqID, result);
+            };
 
-				// Proxy: any property access on $cef auto-creates a channel
-				// object with postMessage. No executeJavaScript injection
-				// needed — channels are available from the first page load
-				// and survive all navigations.
-				$cef = new Proxy($cef, {
-					get: function(target, prop, receiver) {
-						if (prop in target) {
-							return Reflect.get(target, prop, receiver);
-						}
-						if (typeof prop === 'string') {
-							return {
-								postMessage: function(e, r) {
-									$cef.JavaScriptChannel(prop, e, r);
-								}
-							};
-						}
-						return Reflect.get(target, prop, receiver);
-					}
-				});
-			})();
-		 )";
+            // ── $cef.StartRequest(reqId, cmd, callback, args, log) ───────
+            // V8 native function → CefJSHandler::Execute("StartRequest")
+            // → CefJSBridge::StartRequest()
+            // → frame->SendProcessMessage(PID_BROWSER)
+            // → WebviewHandler::OnProcessMessageReceived
+            // → onJavaScriptChannelMessage → Flutter Dart
+            $cef.StartRequest = (nReqID, strCmd, strCallBack,
+                                 strArgs, strLog) => {
+                native function StartRequest();
+                StartRequest(nReqID, strCmd, strCallBack, strArgs, strLog);
+            };
+
+            // ── $cef.GetNextReqID() ──────────────────────────────────────
+            // Monotonically increasing request ID (atomic, thread-safe).
+            // JavaScriptChannel requests use negative IDs to distinguish
+            // them from jsCmd positive IDs in the callback map.
+            $cef.GetNextReqID = () => {
+                native function GetNextReqID();
+                return GetNextReqID();
+            };
+
+            // ── $cef Proxy ──────────────────────────────────────────────
+            // Proxy: any property access on $cef auto-creates a channel
+            // object with postMessage. No executeJavaScript injection
+            // needed — channels are available from the first page load
+            // and survive all navigations.
+            $cef = new Proxy($cef, {
+                get: function(target, prop, receiver) {
+                    if (prop in target) {
+                        return Reflect.get(target, prop, receiver);
+                    }
+                    if (typeof prop === 'string') {
+                        return {
+                            postMessage: function(e, r) {
+                                $cef.JavaScriptChannel(prop, e, r);
+                            }
+                        };
+                    }
+                    return Reflect.get(target, prop, receiver);
+                }
+            });
+        })();
+     )";
 
     CefRefPtr<CefJSHandler> handler = new CefJSHandler();
 

--- a/common/webview_app.cc
+++ b/common/webview_app.cc
@@ -200,8 +200,8 @@ void WebviewApp::SetUnSafelyTreatInsecureOriginAsSecure(const CefString &strFilt
 //
 // Call chain:
 //   Print.postMessage(json)          // JS call (injected by setJavaScriptChannels)
-//     → external.JavaScriptChannel('Print', json)
-//       → external.StartRequest(reqID, 'Print', '', json)
+//     → $cef.JavaScriptChannel('Print', json)
+//       → $cef.StartRequest(reqID, 'Print', '', json)
 //         → [V8 native function] → CefJSHandler::Execute("StartRequest")
 //           → CefJSBridge::StartRequest()
 //             → frame->SendProcessMessage(PID_BROWSER)  ← cross-process
@@ -219,7 +219,7 @@ void WebviewApp::SetUnSafelyTreatInsecureOriginAsSecure(const CefString &strFilt
 //   });
 // ```
 //
-// external namespace:
+// $cef namespace:
 //   JavaScriptChannel(n, e, r) — n=channel name, e=payload, r=optional callback
 //   StartRequest(...)           — V8 native function, sends cross-process message
 //   GetNextReqID()              — monotonic request ID generator
@@ -228,7 +228,7 @@ void WebviewApp::OnWebKitInitialized()
 {
     //inject js function for jssdk
     std::string extensionCode = R"(
-			var external = {};
+			var $cef = {};
 			var clientSdk = {};
 			(() => {
 				clientSdk.jsCmd = (functionName, arg1, arg2, arg3) => {
@@ -256,7 +256,7 @@ void WebviewApp::OnWebKitInitialized()
 					}
 				};
 
-                external.JavaScriptChannel = (n,e,r) => {
+                $cef.JavaScriptChannel = (n,e,r) => {
                     var a; 
                     null == r ? a = '' : (a = '_' + new Date + (1e3 + Math.floor(8999 * Math.random())), window[a] = function (n, e) { 
                         return function () { 
@@ -268,22 +268,22 @@ void WebviewApp::OnWebKitInitialized()
                         } 
                     }(a, r)); 
                     try {
-                        external.StartRequest(external.GetNextReqID(), n, a, JSON.stringify(e || {}), '') 
+                        $cef.StartRequest($cef.GetNextReqID(), n, a, JSON.stringify(e || {}), '') 
                     } catch (l) {
                         console.log('messeage send')
                     }
                 }
 
-                external.EvaluateCallback = (nReqID, result) => {
+                $cef.EvaluateCallback = (nReqID, result) => {
                     native function EvaluateCallback();
                     EvaluateCallback(nReqID, result);
                 }
 
-				external.StartRequest  = (nReqID, strCmd, strCallBack, strArgs, strLog) => {
+				$cef.StartRequest  = (nReqID, strCmd, strCallBack, strArgs, strLog) => {
 					native function StartRequest();
 					StartRequest(nReqID, strCmd, strCallBack, strArgs, strLog);
 				};
-				external.GetNextReqID  = () => {
+				$cef.GetNextReqID  = () => {
 				  native function GetNextReqID();
 				  return GetNextReqID();
 				};

--- a/common/webview_app.cc
+++ b/common/webview_app.cc
@@ -199,7 +199,7 @@ void WebviewApp::SetUnSafelyTreatInsecureOriginAsSecure(const CefString &strFilt
 // Register V8 extension, wire JS ↔ C++ bridge
 //
 // Call chain:
-//   Print.postMessage(json)          // JS call (injected by setJavaScriptChannels)
+//   $cef.Print.postMessage(json)       // JS call — Proxy auto-creates channel object
 //     → $cef.JavaScriptChannel('Print', json)
 //       → $cef.StartRequest(reqID, 'Print', '', json)
 //         → [V8 native function] → CefJSHandler::Execute("StartRequest")
@@ -208,13 +208,18 @@ void WebviewApp::SetUnSafelyTreatInsecureOriginAsSecure(const CefString &strFilt
 //               → WebviewHandler::OnProcessMessageReceived
 //                 → onJavaScriptChannelMessage → Flutter Dart
 //
+// The $cef namespace is wrapped in a JavaScript Proxy: any property access
+// (e.g. $cef.Print, $cef.MyChannel) automatically returns a {postMessage}
+// object. No per-channel executeJavaScript injection is needed. Channels
+// are available from the very first page load and survive all navigations.
+//
 // @example
 // ```javascript
 //   // Fire-and-forget
-//   Print.postMessage(JSON.stringify({msg: 'hello'}));
+//   $cef.Print.postMessage(JSON.stringify({msg: 'hello'}));
 //
 //   // With callback: callback(error, result)
-//   Print.postMessage(JSON.stringify({msg: 'hello'}), function(err, res) {
+//   $cef.Print.postMessage(JSON.stringify({msg: 'hello'}), function(err, res) {
 //     console.log('reply:', res);
 //   });
 // ```
@@ -224,6 +229,7 @@ void WebviewApp::SetUnSafelyTreatInsecureOriginAsSecure(const CefString &strFilt
 //   StartRequest(...)           — V8 native function, sends cross-process message
 //   GetNextReqID()              — monotonic request ID generator
 //   EvaluateCallback(id, val)   — callback channel for evaluateJavascript
+//   <any>                       — Proxy auto-creates {postMessage} for any name
 void WebviewApp::OnWebKitInitialized()
 {
     //inject js function for jssdk
@@ -287,6 +293,26 @@ void WebviewApp::OnWebKitInitialized()
 				  native function GetNextReqID();
 				  return GetNextReqID();
 				};
+
+				// Proxy: any property access on $cef auto-creates a channel
+				// object with postMessage. No executeJavaScript injection
+				// needed — channels are available from the first page load
+				// and survive all navigations.
+				$cef = new Proxy($cef, {
+					get: function(target, prop, receiver) {
+						if (prop in target) {
+							return Reflect.get(target, prop, receiver);
+						}
+						if (typeof prop === 'string') {
+							return {
+								postMessage: function(e, r) {
+									$cef.JavaScriptChannel(prop, e, r);
+								}
+							};
+						}
+						return Reflect.get(target, prop, receiver);
+					}
+				});
 			})();
 		 )";
 

--- a/common/webview_app.cc
+++ b/common/webview_app.cc
@@ -195,6 +195,35 @@ void WebviewApp::SetUnSafelyTreatInsecureOriginAsSecure(const CefString &strFilt
     m_strFilterDomain = strFilterDomain;
 }
 
+
+// Register V8 extension, wire JS ↔ C++ bridge
+//
+// Call chain:
+//   Print.postMessage(json)          // JS call (injected by setJavaScriptChannels)
+//     → external.JavaScriptChannel('Print', json)
+//       → external.StartRequest(reqID, 'Print', '', json)
+//         → [V8 native function] → CefJSHandler::Execute("StartRequest")
+//           → CefJSBridge::StartRequest()
+//             → frame->SendProcessMessage(PID_BROWSER)  ← cross-process
+//               → WebviewHandler::OnProcessMessageReceived
+//                 → onJavaScriptChannelMessage → Flutter Dart
+//
+// @example
+// ```javascript
+//   // Fire-and-forget
+//   Print.postMessage(JSON.stringify({msg: 'hello'}));
+//
+//   // With callback: callback(error, result)
+//   Print.postMessage(JSON.stringify({msg: 'hello'}), function(err, res) {
+//     console.log('reply:', res);
+//   });
+// ```
+//
+// external namespace:
+//   JavaScriptChannel(n, e, r) — n=channel name, e=payload, r=optional callback
+//   StartRequest(...)           — V8 native function, sends cross-process message
+//   GetNextReqID()              — monotonic request ID generator
+//   EvaluateCallback(id, val)   — callback channel for evaluateJavascript
 void WebviewApp::OnWebKitInitialized()
 {
     //inject js function for jssdk

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -102,8 +102,11 @@ bool WebviewHandler::OnProcessMessageReceived(
 
 void WebviewHandler::OnTitleChange(CefRefPtr<CefBrowser> browser,
                                   const CefString& title) {
-    //todo: title change
-    if(onTitleChangedEvent) {
+    auto it = browser_map_.find(browser->GetIdentifier());
+    if (it != browser_map_.end()) {
+        it->second.title = title.ToString();
+    }
+    if (onTitleChangedEvent) {
         onTitleChangedEvent(browser->GetIdentifier(), title);
     }
 }
@@ -111,7 +114,7 @@ void WebviewHandler::OnTitleChange(CefRefPtr<CefBrowser> browser,
 void WebviewHandler::OnAddressChange(CefRefPtr<CefBrowser> browser,
                              CefRefPtr<CefFrame> frame,
                      const CefString& url) {
-    if(onUrlChangedEvent) {
+    if (onUrlChangedEvent) {
         onUrlChangedEvent(browser->GetIdentifier(), url);
     }
 }
@@ -120,7 +123,7 @@ bool WebviewHandler::OnCursorChange(CefRefPtr<CefBrowser> browser,
                             CefCursorHandle cursor,
                             cef_cursor_type_t type,
                             const CefCursorInfo& custom_cursor_info){
-    if(onCursorChangedEvent) {
+    if (onCursorChangedEvent) {
         onCursorChangedEvent(browser->GetIdentifier(), type);
         return true;
     }
@@ -128,7 +131,7 @@ bool WebviewHandler::OnCursorChange(CefRefPtr<CefBrowser> browser,
 }
 
 bool WebviewHandler::OnTooltip(CefRefPtr<CefBrowser> browser, CefString& text) {
-    if(onTooltipEvent) {
+    if (onTooltipEvent) {
         onTooltipEvent(browser->GetIdentifier(), text);
         return true;
     }
@@ -206,15 +209,29 @@ void WebviewHandler::OnLoadError(CefRefPtr<CefBrowser> browser,
     // Don't display an error for downloaded files.
     if (errorCode == ERR_ABORTED)
         return;
-    
-    // Display a load error message using a data: URI.
-    std::stringstream ss;
-    ss << "<html><body bgcolor=\"white\">"
-    "<h2>Failed to load URL "
-    << std::string(failedUrl) << " with error " << std::string(errorText)
-    << " (" << errorCode << ").</h2></body></html>";
-    
-    frame->LoadURL(GetDataURI(ss.str(), "text/html"));
+
+    // Notify Dart so the app can show its own error UI.
+    if (onLoadErrorCallback) {
+        onLoadErrorCallback(browser->GetIdentifier(),
+                            static_cast<int>(errorCode),
+                            errorText.ToString(),
+                            failedUrl.ToString());
+    }
+
+    // The built-in error page is intentionally disabled — it interferes with
+    // goBack/goForward navigation. The Dart listener (onPageFailed) owns error
+    // display now. Uncomment the block below to restore the default error page
+    // when no listener is set:
+    //
+    // if (!onLoadErrorCallback) {
+    //     std::stringstream ss;
+    //     ss << "<html><body bgcolor=\"white\">"
+    //        << "<h2>Failed to load URL "
+    //        << std::string(failedUrl) << " with error "
+    //        << std::string(errorText) << " (" << errorCode
+    //        << ").</h2></body></html>";
+    //     frame->LoadURL(GetDataURI(ss.str(), "text/html"));
+    // }
 }
 
 void WebviewHandler::OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
@@ -231,6 +248,27 @@ void WebviewHandler::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame
         onLoadEnd(browser->GetIdentifier(), frame->GetURL());
     }
     return;
+}
+
+void WebviewHandler::OnLoadingProgressChange(CefRefPtr<CefBrowser> browser,
+                                              double progress) {
+    if (onLoadingProgressChangeCallback) {
+        onLoadingProgressChangeCallback(browser->GetIdentifier(), progress);
+    }
+}
+
+bool WebviewHandler::OnBeforeBrowse(CefRefPtr<CefBrowser> browser,
+                                     CefRefPtr<CefFrame> frame,
+                                     CefRefPtr<CefRequest> request,
+                                     bool user_gesture,
+                                     bool is_redirect) {
+    // Always allow the navigation; notify Dart asynchronously so it can
+    // call stopLoading() if the user wants to cancel.
+    if (onBeforeBrowseCallback) {
+        onBeforeBrowseCallback(browser->GetIdentifier(),
+                               request->GetURL().ToString());
+    }
+    return false; // false = allow navigation
 }
 
 void WebviewHandler::CloseAllBrowsers(bool force_close) {
@@ -481,6 +519,21 @@ void WebviewHandler::reload(int browserId) {
     if (it != browser_map_.end()) {
         it->second.browser->GetMainFrame()->GetBrowser()->Reload();
     }
+}
+
+void WebviewHandler::stopLoading(int browserId) {
+    auto it = browser_map_.find(browserId);
+    if (it != browser_map_.end()) {
+        it->second.browser->StopLoad();
+    }
+}
+
+std::string WebviewHandler::getTitle(int browserId) {
+    auto it = browser_map_.find(browserId);
+    if (it != browser_map_.end()) {
+        return it->second.title;
+    }
+    return "";
 }
 
 void WebviewHandler::openDevTools(int browserId) {

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -234,6 +234,18 @@ void WebviewHandler::OnLoadError(CefRefPtr<CefBrowser> browser,
     // }
 }
 
+void WebviewHandler::OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser,
+                                               TerminationStatus status,
+                                               int error_code,
+                                               const CefString& error_string) {
+    if (onRenderProcessTerminated) {
+        onRenderProcessTerminated(browser->GetIdentifier(),
+                                  static_cast<int>(status),
+                                  error_code,
+                                  error_string.ToString());
+    }
+}
+
 void WebviewHandler::OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
                                  CefLoadHandler::TransitionType transition_type) {
     if(onLoadStart){

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -729,16 +729,11 @@ void WebviewHandler::visitUrlCookies(const std::string& domain, const bool& isHt
 
 void WebviewHandler::setJavaScriptChannels(int browserId, const std::vector<std::string> channels)
 {
-    std::string extensionCode = "try{";
-    for(auto& channel : channels)
-    {
-        extensionCode += "$cef." + channel;
-        extensionCode += " = {postMessage: (e,r) => {$cef.JavaScriptChannel('";
-        extensionCode += channel;
-        extensionCode += "',e,r)}};";
-    }
-    extensionCode += "}catch(e){console.log(e);}";
-    executeJavaScript(browserId, extensionCode);
+    // No-op: the V8 extension ($cef Proxy in OnWebKitInitialized) handles
+    // all channel names automatically. No executeJavaScript injection or
+    // OnLoadEnd re-injection is needed.
+    (void)browserId;
+    (void)channels;
 }
 
 void WebviewHandler::sendJavaScriptChannelCallBack(const bool error, const std::string result, const std::string callbackId, const int browserId, const std::string frameId)

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -664,9 +664,9 @@ void WebviewHandler::setJavaScriptChannels(int browserId, const std::vector<std:
     for(auto& channel : channels)
     {
         extensionCode += channel;
-        extensionCode += " = (e,r) => {external.JavaScriptChannel('";
+        extensionCode += " = {postMessage: (e,r) => {external.JavaScriptChannel('";
         extensionCode += channel;
-        extensionCode += "',e,r)};";
+        extensionCode += "',e,r)}};";
     }
     extensionCode += "}catch(e){console.log(e);}";
     executeJavaScript(browserId, extensionCode);

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -732,8 +732,8 @@ void WebviewHandler::setJavaScriptChannels(int browserId, const std::vector<std:
     std::string extensionCode = "try{";
     for(auto& channel : channels)
     {
-        extensionCode += channel;
-        extensionCode += " = {postMessage: (e,r) => {external.JavaScriptChannel('";
+        extensionCode += "$cef." + channel;
+        extensionCode += " = {postMessage: (e,r) => {$cef.JavaScriptChannel('";
         extensionCode += channel;
         extensionCode += "',e,r)}};";
     }
@@ -784,7 +784,7 @@ void WebviewHandler::executeJavaScript(int browserId, const std::string code, st
                 if(callback != nullptr){
                     std::string callbackId = GetCallbackId();
 
-                    finalCode = "external.EvaluateCallback('";
+                    finalCode = "$cef.EvaluateCallback('";
                     finalCode += callbackId;
                     finalCode += "',(function(){return ";
                     finalCode += code;

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -750,8 +750,23 @@ void WebviewHandler::sendJavaScriptChannelCallBack(const bool error, const std::
         CefRefPtr<CefFrame> frame = bit->second.browser->GetMainFrame();
 
         // CefFrame::GetIdentifier() returns a string identifier in current CEF
-        // (since CEF 122) on every platform.
-        bool identifierMatch = std::stoll(frame->GetIdentifier().ToString()) == frameIdInt;
+        // (since CEF 122) on every platform. The identifier is typically numeric
+        // but may be empty or non-numeric in edge cases (e.g. frame not yet loaded,
+        // renderer process crash). We use atoll() instead of std::stoll() here
+        // because:
+        //
+        //  - std::stoll() throws std::invalid_argument when the input string is
+        //    not a valid integer. In C++ this exception propagates as an uncaught
+        //    C++ exception → std::terminate() → abort() → SIGABRT crash.
+        //
+        //  - atoll() is a C function that returns 0 on parse failure instead of
+        //    throwing. It is safe for untrusted / potentially-empty input.
+        //
+        // CefString::ToString() returns std::string (owned copy); calling .c_str()
+        // on it yields a temporary const char* that atoll can consume. Note that
+        // .c_str() alone on a temporary std::string is safe here because the
+        // temporary lives until the full expression ends (at the semicolon).
+        bool identifierMatch = atoll(frame->GetIdentifier().ToString().c_str()) == frameIdInt;
         if (identifierMatch)
         {
             frame->SendProcessMessage(PID_RENDERER, message);

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -460,6 +460,22 @@ void WebviewHandler::goBack(int browserId) {
     }
 }
 
+bool WebviewHandler::canGoBack(int browserId) {
+    auto it = browser_map_.find(browserId);
+    if (it != browser_map_.end()) {
+        return it->second.browser->CanGoBack();
+    }
+    return false;
+}
+
+bool WebviewHandler::canGoForward(int browserId) {
+    auto it = browser_map_.find(browserId);
+    if (it != browser_map_.end()) {
+        return it->second.browser->CanGoForward();
+    }
+    return false;
+}
+
 void WebviewHandler::reload(int browserId) {
     auto it = browser_map_.find(browserId);
     if (it != browser_map_.end()) {

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -319,7 +319,16 @@ void WebviewHandler::createBrowser(std::string url, std::function<void(int)> cal
     // an IDXGIOutput vblank wait, macOS from a CVDisplayLink.
     window_info.external_begin_frame_enabled = true;
 #endif
-    callback(CefBrowserHost::CreateBrowserSync(window_info, this, url, browser_settings, nullptr, nullptr)->GetIdentifier());
+    CefRefPtr<CefBrowser> browser =
+        CefBrowserHost::CreateBrowserSync(window_info, this, url,
+                                          browser_settings, nullptr, nullptr);
+    if (!browser) {
+        std::cerr << "[webview_cef] ERROR: CreateBrowserSync failed for URL: "
+                  << url << std::endl;
+        callback(-1);  // Invalid browser ID signals creation failure.
+        return;
+    }
+    callback(browser->GetIdentifier());
 #ifdef WEBVIEW_CEF_GPU_TEXTURE
     // The GPU shared-texture path is the only render path on this build (no
     // OnPaint fallback). If no accelerated frame arrives shortly, the GPU

--- a/common/webview_handler.cc
+++ b/common/webview_handler.cc
@@ -482,6 +482,57 @@ void WebviewHandler::sendKeyEvent(CefKeyEvent& ev)
     if (!browser.get()) {
         return;
     }
+
+    // Intercept DevTools keyboard shortcuts before forwarding the key to the
+    // page so the shortcut does not reach the web content.
+    if (ev.type == KEYEVENT_RAWKEYDOWN) {
+        bool open = false;
+
+        // F12 — mapped to VK_F12 (0x7B) on Windows/Linux, native key code 111
+        // on macOS (CEF off-screen rendering does not populate windows_key_code
+        // from NSEvent).
+#ifdef OS_MAC
+        if (ev.native_key_code == 111) {  // F12 on macOS
+            open = true;
+        }
+#else
+        if (ev.windows_key_code == 0x7B) {  // VK_F12
+            open = true;
+        }
+#endif
+
+        // Cmd+Opt+I (macOS) / Ctrl+Shift+I (Windows/Linux).
+        // Use unmodified_character so the check is independent of the Shift
+        // modifier state; fall back to character when it is unset.
+        char16_t ch = ev.unmodified_character != 0 ? ev.unmodified_character
+                                                    : ev.character;
+        if (ch == 'I' || ch == 'i') {
+#ifdef OS_MAC
+            if ((ev.modifiers & (EVENTFLAG_COMMAND_DOWN |
+                                 EVENTFLAG_ALT_DOWN)) ==
+                (EVENTFLAG_COMMAND_DOWN | EVENTFLAG_ALT_DOWN)) {
+                open = true;
+            }
+#else
+            if ((ev.modifiers & (EVENTFLAG_CONTROL_DOWN |
+                                 EVENTFLAG_SHIFT_DOWN)) ==
+                (EVENTFLAG_CONTROL_DOWN | EVENTFLAG_SHIFT_DOWN)) {
+                open = true;
+            }
+#endif
+        }
+
+        if (open) {
+            CefWindowInfo windowInfo;
+#ifdef OS_WIN
+            windowInfo.SetAsPopup(nullptr, "DevTools");
+#endif
+            browser->GetHost()->ShowDevTools(windowInfo, this,
+                                             CefBrowserSettings(), CefPoint());
+            return;  // Consume the shortcut — do not forward to the web page.
+        }
+    }
+
     browser->GetHost()->SendKeyEvent(ev);
 }
 

--- a/common/webview_handler.h
+++ b/common/webview_handler.h
@@ -172,6 +172,8 @@ public:
     void loadUrl(int browserId, std::string url);
     void goForward(int browserId);
     void goBack(int browserId);
+    bool canGoBack(int browserId);
+    bool canGoForward(int browserId);
     void reload(int browserId);
     void openDevTools(int browserId);
 

--- a/common/webview_handler.h
+++ b/common/webview_handler.h
@@ -34,6 +34,7 @@ struct browser_info{
     // right after creation is lost; we re-apply it once the first frame lands.
     bool wants_focus = false;
     bool focus_reasserted = false;
+    std::string title;
 };
 
 class WebviewHandler : public CefClient,
@@ -41,7 +42,8 @@ public CefDisplayHandler,
 public CefLifeSpanHandler,
 public CefFocusHandler,
 public CefLoadHandler,
-public CefRenderHandler{
+public CefRenderHandler,
+public CefRequestHandler{
 public:
     //Paint callback (software off-screen rendering)
     std::function<void(int browserId, const void* buffer, int32_t width, int32_t height)> onPaintCallback;
@@ -61,6 +63,12 @@ public:
     std::function<void(std::string, std::string, std::string, int browserId, std::string)> onJavaScriptChannelMessage;
     std::function<void(int browserId, std::string url)> onLoadStart;
     std::function<void(int browserId, std::string url)> onLoadEnd;
+    // Navigation / loading callback (before navigation starts)
+    std::function<void(int browserId, std::string url)> onBeforeBrowseCallback;
+    // Loading progress (0.0 – 1.0)
+    std::function<void(int browserId, double progress)> onLoadingProgressChangeCallback;
+    // Page load error
+    std::function<void(int browserId, int errorCode, std::string errorText, std::string failedUrl)> onLoadErrorCallback;
     
     explicit WebviewHandler();
     ~WebviewHandler();
@@ -77,6 +85,7 @@ public:
     }
     virtual CefRefPtr<CefLoadHandler> GetLoadHandler() override { return this; }
     virtual CefRefPtr<CefRenderHandler> GetRenderHandler() override { return this; }
+    virtual CefRefPtr<CefRequestHandler> GetRequestHandler() override { return this; }
 
 	bool OnProcessMessageReceived(
         CefRefPtr<CefBrowser> browser,
@@ -136,7 +145,18 @@ public:
     virtual void OnLoadStart(CefRefPtr<CefBrowser> browser,
                              CefRefPtr<CefFrame> frame,
                              CefLoadHandler::TransitionType transition_type) override;
-    
+
+    // CefDisplayHandler methods (continued):
+    virtual void OnLoadingProgressChange(CefRefPtr<CefBrowser> browser,
+                                         double progress) override;
+
+    // CefRequestHandler methods:
+    virtual bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser,
+                                CefRefPtr<CefFrame> frame,
+                                CefRefPtr<CefRequest> request,
+                                bool user_gesture,
+                                bool is_redirect) override;
+
     // CefRenderHandler methods:
     virtual void GetViewRect(CefRefPtr<CefBrowser> browser, CefRect& rect) override;
     virtual void OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType type, const RectList& dirtyRects, const void* buffer, int width, int height) override;
@@ -175,6 +195,8 @@ public:
     bool canGoBack(int browserId);
     bool canGoForward(int browserId);
     void reload(int browserId);
+    void stopLoading(int browserId);
+    std::string getTitle(int browserId);
     void openDevTools(int browserId);
 
     void imeSetComposition(int browserId, std::string text);

--- a/common/webview_handler.h
+++ b/common/webview_handler.h
@@ -69,6 +69,11 @@ public:
     std::function<void(int browserId, double progress)> onLoadingProgressChangeCallback;
     // Page load error
     std::function<void(int browserId, int errorCode, std::string errorText, std::string failedUrl)> onLoadErrorCallback;
+    // Render process terminated unexpectedly (crash / OOM / killed).
+    // |status|: TS_ABNORMAL_TERMINATION (0), TS_PROCESS_WAS_KILLED (1),
+    // TS_PROCESS_CRASHED (2) or TS_PROCESS_OOM (3). Use controller.reload()
+    // to restore the page — CEF already created a new render process.
+    std::function<void(int browserId, int status, int errorCode, std::string errorString)> onRenderProcessTerminated;
     
     explicit WebviewHandler();
     ~WebviewHandler();
@@ -156,6 +161,10 @@ public:
                                 CefRefPtr<CefRequest> request,
                                 bool user_gesture,
                                 bool is_redirect) override;
+    virtual void OnRenderProcessTerminated(CefRefPtr<CefBrowser> browser,
+                                           TerminationStatus status,
+                                           int error_code,
+                                           const CefString& error_string) override;
 
     // CefRenderHandler methods:
     virtual void GetViewRect(CefRefPtr<CefBrowser> browser, CefRect& rect) override;

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -341,6 +341,16 @@ namespace webview_cef {
 			m_handler->goBack(browserId);
 			result(1, nullptr);
 		}
+		else if (name.compare("canGoBack") == 0) {
+			int browserId = int(webview_value_get_int(values));
+			bool val = m_handler->canGoBack(browserId);
+			result(1, webview_value_new_bool(val));
+		}
+		else if (name.compare("canGoForward") == 0) {
+			int browserId = int(webview_value_get_int(values));
+			bool val = m_handler->canGoForward(browserId);
+			result(1, webview_value_new_bool(val));
+		}
 		else if (name.compare("reload") == 0) {
 			int browserId = int(webview_value_get_int(values));
 			m_handler->reload(browserId);

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -245,6 +245,54 @@ namespace webview_cef {
                 }
             };
 
+            m_handler->onBeforeBrowseCallback = [=, this](int nBrowserId, std::string url) {
+                if (m_invokeFunc) {
+                    WValue* bId = webview_value_new_int(nBrowserId);
+                    WValue* uId = webview_value_new_string(const_cast<char*>(url.c_str()));
+                    WValue* retMap = webview_value_new_map();
+                    webview_value_set_string(retMap, "browserId", bId);
+                    webview_value_set_string(retMap, "url", uId);
+                    m_invokeFunc("onBeforeBrowse", retMap);
+                    webview_value_unref(bId);
+                    webview_value_unref(uId);
+                    webview_value_unref(retMap);
+                }
+            };
+
+            m_handler->onLoadingProgressChangeCallback = [=, this](int nBrowserId, double progress) {
+                if (m_invokeFunc) {
+                    WValue* bId = webview_value_new_int(nBrowserId);
+                    WValue* prog = webview_value_new_double(progress);
+                    WValue* retMap = webview_value_new_map();
+                    webview_value_set_string(retMap, "browserId", bId);
+                    webview_value_set_string(retMap, "progress", prog);
+                    m_invokeFunc("onLoadingProgressChange", retMap);
+                    webview_value_unref(bId);
+                    webview_value_unref(prog);
+                    webview_value_unref(retMap);
+                }
+            };
+
+            m_handler->onLoadErrorCallback = [=, this](int nBrowserId, int errorCode, std::string errorText, std::string failedUrl) {
+                if (m_invokeFunc) {
+                    WValue* bId = webview_value_new_int(nBrowserId);
+                    WValue* code = webview_value_new_int(errorCode);
+                    WValue* text = webview_value_new_string(const_cast<char*>(errorText.c_str()));
+                    WValue* url = webview_value_new_string(const_cast<char*>(failedUrl.c_str()));
+                    WValue* retMap = webview_value_new_map();
+                    webview_value_set_string(retMap, "browserId", bId);
+                    webview_value_set_string(retMap, "errorCode", code);
+                    webview_value_set_string(retMap, "errorText", text);
+                    webview_value_set_string(retMap, "url", url);
+                    m_invokeFunc("onLoadError", retMap);
+                    webview_value_unref(bId);
+                    webview_value_unref(code);
+                    webview_value_unref(text);
+                    webview_value_unref(url);
+                    webview_value_unref(retMap);
+                }
+            };
+
 			m_init = true;
 		}
 	}
@@ -260,6 +308,9 @@ namespace webview_cef {
 		m_handler->onJavaScriptChannelMessage = nullptr;
 		m_handler->onFocusedNodeChangeMessage = nullptr;
 		m_handler->onImeCompositionRangeChangedMessage = nullptr;
+		m_handler->onBeforeBrowseCallback = nullptr;
+		m_handler->onLoadingProgressChangeCallback = nullptr;
+		m_handler->onLoadErrorCallback = nullptr;
 		m_init = false;
 	}
 
@@ -354,6 +405,18 @@ namespace webview_cef {
 		else if (name.compare("reload") == 0) {
 			int browserId = int(webview_value_get_int(values));
 			m_handler->reload(browserId);
+			result(1, nullptr);
+		}
+		else if (name.compare("getTitle") == 0) {
+			int browserId = int(webview_value_get_int(values));
+			std::string title = m_handler->getTitle(browserId);
+			WValue* ret = webview_value_new_string(title.c_str());
+			result(1, ret);
+			webview_value_unref(ret);
+		}
+		else if (name.compare("stopLoading") == 0) {
+			int browserId = int(webview_value_get_int(values));
+			m_handler->stopLoading(browserId);
 			result(1, nullptr);
 		}
 		else if (name.compare("openDevTools") == 0) {			

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -15,6 +15,7 @@ namespace webview_cef {
 	CefRefPtr<WebviewApp> app;
 	CefString userAgent;
 	bool isCefInitialized = false;
+	std::string g_cefCachePath;
 #ifdef OS_MAC
 	std::string g_macSubprocessPath;
 	std::string g_macFrameworkDirPath;
@@ -28,6 +29,9 @@ namespace webview_cef {
 		g_macMainBundlePath = mainBundlePath;
 	}
 #endif
+	void setCefCachePath(const std::string& cachePath) {
+		g_cefCachePath = cachePath;
+	}
 
 	WebviewPlugin::WebviewPlugin() {
 		m_handler = new WebviewHandler();
@@ -329,6 +333,10 @@ namespace webview_cef {
 						if (ua != nullptr && webview_value_get_type(ua) == Webview_Value_Type_String) {
 							userAgent = CefString(webview_value_get_string(ua));
 						}
+						WValue* cp = webview_value_get_by_string(values, "cachePath");
+						if (cp != nullptr && webview_value_get_type(cp) == Webview_Value_Type_String) {
+							setCefCachePath(webview_value_get_string(cp));
+						}
 					} else {
 						// Old API: init arg is a bare string (userAgent).
 						userAgent = CefString(webview_value_get_string(values));
@@ -347,6 +355,13 @@ namespace webview_cef {
 		else if (name.compare("create") == 0) {
 			std::string url = webview_value_get_string(values);
 			m_handler->createBrowser(url, [=, this](int browserId) {
+				if (browserId < 0) {
+					std::cerr << "[webview_cef] ERROR: createBrowser failed, "
+					             "browser creation returned invalid ID."
+					          << std::endl;
+					result(0, nullptr);
+					return;
+				}
 				std::shared_ptr<WebviewTexture> renderer = m_createTextureFunc();
 				m_renderers[browserId] = renderer;
 				WValue	*response = webview_value_new_list();
@@ -828,6 +843,9 @@ namespace webview_cef {
 		//cef message run in another thread on windows/linux
 		cefs.multi_threaded_message_loop = true;
 #endif
+		if (!g_cefCachePath.empty()) {
+			CefString(&cefs.root_cache_path) = g_cefCachePath;
+		}
 		CefInitialize(mainArgs, cefs, app.get(), nullptr);
 	}
 

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -319,7 +319,20 @@ namespace webview_cef {
 		if (name.compare("init") == 0){
 			if(!isCefInitialized){
 				if(values != nullptr){
-					userAgent = CefString(webview_value_get_string(values));
+					if (webview_value_get_type(values) == Webview_Value_Type_Map) {
+						// New API: init args are a map with named keys.
+						WValue* pm = webview_value_get_by_string(values, "processMode");
+						if (pm != nullptr && webview_value_get_type(pm) == Webview_Value_Type_Int) {
+							app->SetProcessMode(static_cast<uint32_t>(webview_value_get_int(pm)));
+						}
+						WValue* ua = webview_value_get_by_string(values, "userAgent");
+						if (ua != nullptr && webview_value_get_type(ua) == Webview_Value_Type_String) {
+							userAgent = CefString(webview_value_get_string(ua));
+						}
+					} else {
+						// Old API: init arg is a bare string (userAgent).
+						userAgent = CefString(webview_value_get_string(values));
+					}
 				}
 				startCEF();
 			}

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -696,28 +696,122 @@ namespace webview_cef {
 
 	void WebviewPlugin::sendKeyEvent(CefKeyEvent& ev)
 	{
-		// CEF off-screen rendering bypasses AppKit's interpretKeyEvents: which maps
-		// macOS Cmd+Backspace to the deleteToBeginningOfLine editing command.
-		// Intercept it here and execute the editing action via JavaScript.
-		if (ev.type == KEYEVENT_RAWKEYDOWN &&
-		    ev.native_key_code == 51 &&
-		    (ev.modifiers & EVENTFLAG_COMMAND_DOWN) &&
-		    !(ev.modifiers & EVENTFLAG_SHIFT_DOWN)) {
-			int bId = focusedBrowserId();
-			if (bId >= 0) {
-				m_handler->executeJavaScript(bId,
-					"(function(){var e=document.activeElement;"
-					"if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
-					"var p=e.selectionStart;if(p===e.selectionEnd&&p>0){"
-					"var v=e.value,ls=v.lastIndexOf('\\n',p-1);"
-					"ls=(ls===-1)?0:ls+1;e.setSelectionRange(ls,p);"
-					"}}document.execCommand('delete',false,null)})()");
-			}
+#ifdef OS_MAC
+		// CEF off-screen rendering bypasses AppKit's interpretKeyEvents: which
+		// maps macOS Cmd+Arrow / Cmd+Z / Cmd+Backspace to editing commands.
+		// Intercept them here and execute the editing action via JavaScript.
+		if (handleMacOSOSRShortcut(ev)) {
 			return;
 		}
-
+#endif
 		m_handler->sendKeyEvent(ev);
 	}
+
+#ifdef OS_MAC
+	bool WebviewPlugin::handleMacOSOSRShortcut(CefKeyEvent& ev)
+	{
+		// Only intercept RAWKEYDOWN events with Command modifier.
+		if (ev.type != KEYEVENT_RAWKEYDOWN ||
+		    !(ev.modifiers & EVENTFLAG_COMMAND_DOWN)) {
+			return false;
+		}
+
+		int bId = focusedBrowserId();
+		if (bId < 0) return false;
+
+		bool shiftDown = (ev.modifiers & EVENTFLAG_SHIFT_DOWN) != 0;
+		const char* js = nullptr;
+
+		switch (ev.native_key_code) {
+		case 51:  // Backspace — delete to beginning of line.
+			if (!shiftDown) {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "var p=e.selectionStart;if(p===e.selectionEnd&&p>0){"
+				     "var v=e.value,ls=v.lastIndexOf('\\n',p-1);"
+				     "ls=(ls===-1)?0:ls+1;e.setSelectionRange(ls,p);"
+				     "}}document.execCommand('delete',false,null)})()";
+			}
+			break;
+
+		case 126:  // Up arrow — beginning of document.
+			if (shiftDown) {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "var p=Math.max(e.selectionStart,e.selectionEnd);"
+				     "e.setSelectionRange(p,0);}})()";
+			} else {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "e.setSelectionRange(0,0);}})()";
+			}
+			break;
+
+		case 125:  // Down arrow — end of document.
+			if (shiftDown) {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "var p=Math.min(e.selectionStart,e.selectionEnd);"
+				     "var l=e.value.length;e.setSelectionRange(p,l);}})()";
+			} else {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "var l=e.value.length;e.setSelectionRange(l,l);}})()";
+			}
+			break;
+
+		case 123:  // Left arrow — beginning of line.
+			if (shiftDown) {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "var v=e.value,p=Math.max(e.selectionStart,e.selectionEnd);"
+				     "var ls=v.lastIndexOf('\\n',p-1);"
+				     "ls=(ls===-1)?0:ls+1;e.setSelectionRange(p,ls);}})()";
+			} else {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "var v=e.value,p=e.selectionStart;"
+				     "var ls=v.lastIndexOf('\\n',p-1);"
+				     "ls=(ls===-1)?0:ls+1;e.setSelectionRange(ls,ls);}})()";
+			}
+			break;
+
+		case 124:  // Right arrow — end of line.
+			if (shiftDown) {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "var v=e.value,p=Math.min(e.selectionStart,e.selectionEnd);"
+				     "var le=v.indexOf('\\n',p);"
+				     "le=(le===-1)?v.length:le;e.setSelectionRange(p,le);}})()";
+			} else {
+				js = "(function(){var e=document.activeElement;"
+				     "if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+				     "var v=e.value,p=e.selectionEnd;"
+				     "var le=v.indexOf('\\n',p);"
+				     "le=(le===-1)?v.length:le;e.setSelectionRange(le,le);}})()";
+			}
+			break;
+
+		case 6:  // Z — undo / redo (no element check; execCommand works
+		         // at the document level for contenteditable as well).
+			if (shiftDown) {
+				js = "(function(){document.execCommand('redo')})()";
+			} else {
+				js = "(function(){document.execCommand('undo')})()";
+			}
+			break;
+
+		default:
+			return false;
+		}
+
+		if (js) {
+			m_handler->executeJavaScript(bId, js);
+			return true;
+		}
+		return false;
+	}
+#endif
 
 	void WebviewPlugin::setInvokeMethodFunc(std::function<void(std::string, WValue*)> func){
 		m_invokeFunc = func;

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -792,6 +792,14 @@ namespace webview_cef {
 			}
 			break;
 
+
+		case 8:  // C — copy (no element restriction; copies the current
+		         // selection, whether inside an input or in the DOM at large).
+			if (!shiftDown) {
+				js = "(function(){document.execCommand('copy')})()";
+			}
+			break;
+
 		case 6:  // Z — undo / redo (no element check; execCommand works
 		         // at the document level for contenteditable as well).
 			if (shiftDown) {
@@ -810,6 +818,40 @@ namespace webview_cef {
 			return true;
 		}
 		return false;
+	}
+
+	void WebviewPlugin::pasteText(const std::string& text) {
+		int bId = focusedBrowserId();
+		if (bId < 0) return;
+
+		// Escape the clipboard text for a JavaScript string literal.
+		std::string escaped;
+		escaped.reserve(text.size() * 2);
+		for (char c : text) {
+			switch (c) {
+				case '\\': escaped += "\\\\"; break;
+				case '"':  escaped += "\\\""; break;
+				case '\n': escaped += "\\n";  break;
+				case '\r': escaped += "\\r";  break;
+				case '\t': escaped += "\\t";  break;
+				default:   escaped += c;      break;
+			}
+		}
+
+		std::string js =
+			"(function(t){"
+			"var e=document.activeElement;"
+			"if(!e)return;"
+			"if(e.tagName==='INPUT'||e.tagName==='TEXTAREA'){"
+			"var s=e.selectionStart,p=e.selectionEnd,v=e.value;"
+			"e.value=v.substring(0,s)+t+v.substring(p);"
+			"e.selectionStart=e.selectionEnd=s+t.length;"
+			"e.dispatchEvent(new Event('input',{bubbles:true}));"
+			"}else if(e.isContentEditable||e.getAttribute('contenteditable')==='true'){"
+			"document.execCommand('insertText',false,t);"
+			"}})(\"" + escaped + "\")";
+
+		m_handler->executeJavaScript(bId, js);
 	}
 #endif
 

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -297,6 +297,26 @@ namespace webview_cef {
                 }
             };
 
+            m_handler->onRenderProcessTerminated = [=, this](int nBrowserId, int status, int errorCode, std::string errorString) {
+                if (m_invokeFunc) {
+                    WValue* bId = webview_value_new_int(nBrowserId);
+                    WValue* s = webview_value_new_int(status);
+                    WValue* code = webview_value_new_int(errorCode);
+                    WValue* errStr = webview_value_new_string(const_cast<char*>(errorString.c_str()));
+                    WValue* retMap = webview_value_new_map();
+                    webview_value_set_string(retMap, "browserId", bId);
+                    webview_value_set_string(retMap, "status", s);
+                    webview_value_set_string(retMap, "errorCode", code);
+                    webview_value_set_string(retMap, "errorString", errStr);
+                    m_invokeFunc("onRenderProcessTerminated", retMap);
+                    webview_value_unref(bId);
+                    webview_value_unref(s);
+                    webview_value_unref(code);
+                    webview_value_unref(errStr);
+                    webview_value_unref(retMap);
+                }
+            };
+
 			m_init = true;
 		}
 	}
@@ -315,6 +335,7 @@ namespace webview_cef {
 		m_handler->onBeforeBrowseCallback = nullptr;
 		m_handler->onLoadingProgressChangeCallback = nullptr;
 		m_handler->onLoadErrorCallback = nullptr;
+		m_handler->onRenderProcessTerminated = nullptr;
 		m_init = false;
 	}
 

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -696,13 +696,6 @@ namespace webview_cef {
 		}
 
 		m_handler->sendKeyEvent(ev);
-		if(ev.type == KEYEVENT_RAWKEYDOWN && ev.windows_key_code == 0x7B && (ev.modifiers & EVENTFLAG_CONTROL_DOWN) != 0){
-			for(auto render : m_renderers){
-				if(render.second.get()->isFocused){
-					m_handler->openDevTools(render.first);
-				}
-			}
-		}
 	}
 
 	void WebviewPlugin::setInvokeMethodFunc(std::function<void(std::string, WValue*)> func){

--- a/common/webview_plugin.cc
+++ b/common/webview_plugin.cc
@@ -574,6 +574,26 @@ namespace webview_cef {
 
 	void WebviewPlugin::sendKeyEvent(CefKeyEvent& ev)
 	{
+		// CEF off-screen rendering bypasses AppKit's interpretKeyEvents: which maps
+		// macOS Cmd+Backspace to the deleteToBeginningOfLine editing command.
+		// Intercept it here and execute the editing action via JavaScript.
+		if (ev.type == KEYEVENT_RAWKEYDOWN &&
+		    ev.native_key_code == 51 &&
+		    (ev.modifiers & EVENTFLAG_COMMAND_DOWN) &&
+		    !(ev.modifiers & EVENTFLAG_SHIFT_DOWN)) {
+			int bId = focusedBrowserId();
+			if (bId >= 0) {
+				m_handler->executeJavaScript(bId,
+					"(function(){var e=document.activeElement;"
+					"if(e&&(e.tagName==='INPUT'||e.tagName==='TEXTAREA')){"
+					"var p=e.selectionStart;if(p===e.selectionEnd&&p>0){"
+					"var v=e.value,ls=v.lastIndexOf('\\n',p-1);"
+					"ls=(ls===-1)?0:ls+1;e.setSelectionRange(ls,p);"
+					"}}document.execCommand('delete',false,null)})()");
+			}
+			return;
+		}
+
 		m_handler->sendKeyEvent(ev);
 		if(ev.type == KEYEVENT_RAWKEYDOWN && ev.windows_key_code == 0x7B && (ev.modifiers & EVENTFLAG_CONTROL_DOWN) != 0){
 			for(auto render : m_renderers){

--- a/common/webview_plugin.h
+++ b/common/webview_plugin.h
@@ -72,6 +72,12 @@ namespace webview_cef {
                         const std::string& frameworkDirPath,
                         const std::string& mainBundlePath);
 #endif
+    // Set an explicit root cache path for CEF so that multiple instances of the
+    // same CEF-based app — or different apps embedding the same CEF framework —
+    // each get their own isolated cache directory. Must be called before
+    // startCEF(). On macOS the platform layer passes
+    // ~/Library/Caches/<bundle_id>/cef.
+    void setCefCachePath(const std::string& cachePath);
     void doMessageLoopWork();
     void SwapBufferFromBgraToRgba(void* _dest, const void* _src, int width, int height);
     void stopCEF();

--- a/common/webview_plugin.h
+++ b/common/webview_plugin.h
@@ -46,6 +46,12 @@ namespace webview_cef {
         void imeSetCompositionNative(const std::wstring& text, int cursor);
         void imeCommitTextNative(const std::wstring& text);
         void imeFinishCompositionNative();
+#ifdef OS_MAC
+        // Inject text at the cursor position of the currently focused element
+        // (input / textarea / contenteditable) via JavaScript. Used to paste
+        // system clipboard content that CEF OSR cannot access on its own.
+        void pasteText(const std::string& text);
+#endif
 
     private :
         // Resolve the browserId whose renderer currently has focus, or -1.

--- a/common/webview_plugin.h
+++ b/common/webview_plugin.h
@@ -52,6 +52,15 @@ namespace webview_cef {
         int focusedBrowserId();
         // Set the composing flag for a specific browser (no-op if unknown).
         void setComposingForBrowser(int browserId, bool composing);
+#ifdef OS_MAC
+        // Intercept macOS Cmd+Arrow / Cmd+Z editing shortcuts. CEF off-screen
+        // rendering bypasses AppKit's interpretKeyEvents: so these key chords
+        // never translate to NSEvent editing selectors. Execute the equivalent
+        // editing action via JavaScript instead.
+        // Returns true if the event was handled; caller should return without
+        // forwarding to CEF.
+        bool handleMacOSOSRShortcut(CefKeyEvent& ev);
+#endif
         int cursorAction(WValue *args, std::string name);
     	std::function<void(std::string, WValue*)> m_invokeFunc;
 	    std::function<std::shared_ptr<WebviewTexture>()> m_createTextureFunc;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# webview_cef 内部实现文档
+
+`webview_cef` 是一个 Flutter 插件，通过嵌入 CEF（Chromium Embedded Framework）内核，
+为 macOS、Windows、Linux 和 eLinux 提供 WebView 能力。
+
+## 文档目录
+
+| 文档 | 内容 |
+|------|------|
+| [架构概览](chapter/1-架构概览.md) | 分层架构、进程模型、数据流、关键设计决策 |
+| [Dart 层 API](chapter/2-Dart层API.md) | WebviewManager、WebViewController、WebView widget、事件监听、JS 通道、IME、用户脚本 |
+| [通用 C++ 层](chapter/3-通用C++层.md) | WebviewPlugin、WebviewHandler、WebviewApp、WValue、WebviewTexture |
+| [JSBridge 详解](chapter/4-JSBridge详解.md) | V8 扩展、CefJSBridge、跨进程消息、JavaScriptChannel 与 evaluateJavascript 的完整调用链 |
+| [渲染管线](chapter/5-渲染管线.md) | GPU 零拷贝 vs 软件回退、macOS Metal / Windows D3D11、外部帧时钟 |
+| [平台输入处理](chapter/6-平台输入处理.md) | 鼠标/指针、macOS/Windows/Linux/eLinux 键盘、IME 组合输入 |
+| [构建与集成](chapter/7-构建与集成.md) | macOS CocoaPods、Windows/Linux/eLinux CMake、CEF 下载、编译标志 |
+
+## 核心文件速查
+
+| 想了解... | 看这个文件 |
+|-----------|----------|
+| Dart 入口和事件分发 | `lib/src/webview_manager.dart` |
+| WebView widget 和控制器的全部代码 | `lib/src/webview.dart` |
+| C++ 方法调度中枢（所有 MethodChannel 调用在此分发） | `common/webview_plugin.cc` |
+| CEF 客户端实现（浏览器生命周期、渲染、输入） | `common/webview_handler.h/cc` |
+| V8 扩展和 JS 桥接 | `common/webview_app.cc` + `common/webview_js_handler.cc` |
+| 最完整的平台适配参考 | `macos/Classes/CefWrapper.mm` |
+
+## 阅读顺序建议
+
+1. 先读 [架构概览](chapter/1-架构概览.md) 建立全局认知
+2. 再读 [Dart 层 API](chapter/2-Dart层API.md) 了解对外接口
+3. 然后读 [通用 C++ 层](chapter/3-通用C++层.md) 了解核心实现
+4. [JSBridge 详解](chapter/4-JSBridge详解.md) 是最复杂的子系统，建议在理解前两者后阅读
+5. [渲染管线](chapter/5-渲染管线.md) 和 [平台输入处理](chapter/6-平台输入处理.md) 可按需查阅
+6. [构建与集成](chapter/7-构建与集成.md) 在需要了解编译配置时查阅

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@
 | [平台输入处理](chapter/6-平台输入处理.md) | 鼠标/指针、macOS/Windows/Linux/eLinux 键盘、IME 组合输入 |
 | [构建与集成](chapter/7-构建与集成.md) | macOS CocoaPods、Windows/Linux/eLinux CMake、CEF 下载、编译标志 |
 | [macOS Universal 构建](chapter/8-macOS%20Universal构建.md) | arm64 + x86_64 双架构 fat binary 构建方案，含回退机制 |
+| [CEF 详解](chapter/9-CEF%E8%AF%A6%E8%A7%A3.md) | CEF 多进程架构、文件结构、Helper 应用、渲染模式、缓存目录、命令行开关 |
+| [新旧项目差异对比](chapter/10-%E6%96%B0%E6%97%A7%E9%A1%B9%E7%9B%AE%E5%B7%AE%E5%BC%82%E5%AF%B9%E6%AF%94.md) | 旧项目（cef_flutter）与新项目（webview_cef）在 CEF 版本、Helper 构建、代码架构、渲染管线、JSBridge 等多维度的全面对比 |
 
 ## 核心文件速查
 
@@ -38,3 +40,5 @@
 6. [渲染管线](chapter/5-渲染管线.md) 和 [平台输入处理](chapter/6-平台输入处理.md) 可按需查阅
 7. [构建与集成](chapter/7-构建与集成.md) 在需要了解编译配置时查阅
 8. [macOS Universal 构建](chapter/8-macOS%20Universal构建.md) 在需要打双架构 release 包或配置 CI 时查阅
+9. [CEF 详解](chapter/9-CEF详解.md) 在需要了解 CEF 本身的文件、进程、子进程机制时查阅
+10. [新旧项目差异对比](chapter/10-新旧项目差异对比.md) 在对比旧项目实现或验证迁移完整性时查阅

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 | [渲染管线](chapter/5-渲染管线.md) | GPU 零拷贝 vs 软件回退、macOS Metal / Windows D3D11、外部帧时钟 |
 | [平台输入处理](chapter/6-平台输入处理.md) | 鼠标/指针、macOS/Windows/Linux/eLinux 键盘、IME 组合输入 |
 | [构建与集成](chapter/7-构建与集成.md) | macOS CocoaPods、Windows/Linux/eLinux CMake、CEF 下载、编译标志 |
+| [macOS Universal 构建](chapter/8-macOS%20Universal构建.md) | arm64 + x86_64 双架构 fat binary 构建方案，含回退机制 |
 
 ## 核心文件速查
 
@@ -36,3 +37,4 @@
 5. [JSBridge 详解](chapter/4-JSBridge详解.md) 是最复杂的子系统，建议在理解前两者后阅读
 6. [渲染管线](chapter/5-渲染管线.md) 和 [平台输入处理](chapter/6-平台输入处理.md) 可按需查阅
 7. [构建与集成](chapter/7-构建与集成.md) 在需要了解编译配置时查阅
+8. [macOS Universal 构建](chapter/8-macOS%20Universal构建.md) 在需要打双架构 release 包或配置 CI 时查阅

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 
 | 文档 | 内容 |
 |------|------|
+| [白话理解](chapter/0-白话理解.md) | **推荐先读** — 口语化讲解核心方案、关键链路和设计决策，附带大量举例 |
 | [架构概览](chapter/1-架构概览.md) | 分层架构、进程模型、数据流、关键设计决策 |
 | [Dart 层 API](chapter/2-Dart层API.md) | WebviewManager、WebViewController、WebView widget、事件监听、JS 通道、IME、用户脚本 |
 | [通用 C++ 层](chapter/3-通用C++层.md) | WebviewPlugin、WebviewHandler、WebviewApp、WValue、WebviewTexture |
@@ -28,9 +29,10 @@
 
 ## 阅读顺序建议
 
-1. 先读 [架构概览](chapter/1-架构概览.md) 建立全局认知
-2. 再读 [Dart 层 API](chapter/2-Dart层API.md) 了解对外接口
-3. 然后读 [通用 C++ 层](chapter/3-通用C++层.md) 了解核心实现
-4. [JSBridge 详解](chapter/4-JSBridge详解.md) 是最复杂的子系统，建议在理解前两者后阅读
-5. [渲染管线](chapter/5-渲染管线.md) 和 [平台输入处理](chapter/6-平台输入处理.md) 可按需查阅
-6. [构建与集成](chapter/7-构建与集成.md) 在需要了解编译配置时查阅
+1. **先读** [白话理解](chapter/0-白话理解.md) — 用大白话和举例讲清楚整体方案，不需要技术背景
+2. 再读 [架构概览](chapter/1-架构概览.md) 建立全局认知
+3. 再读 [Dart 层 API](chapter/2-Dart层API.md) 了解对外接口
+4. 然后读 [通用 C++ 层](chapter/3-通用C++层.md) 了解核心实现
+5. [JSBridge 详解](chapter/4-JSBridge详解.md) 是最复杂的子系统，建议在理解前两者后阅读
+6. [渲染管线](chapter/5-渲染管线.md) 和 [平台输入处理](chapter/6-平台输入处理.md) 可按需查阅
+7. [构建与集成](chapter/7-构建与集成.md) 在需要了解编译配置时查阅

--- a/docs/chapter/0-白话理解.md
+++ b/docs/chapter/0-白话理解.md
@@ -1,0 +1,225 @@
+# 白话理解 webview_cef
+
+## 这个项目是干嘛的？
+
+你想在 macOS 或 Windows 的 Flutter 桌面应用里嵌入一个浏览器，用来加载网页、跑 JavaScript、和网页双向通信。Flutter 官方只提供了 Android/iOS 的 WebView，桌面端是空白——这个项目填补了这个空白。
+
+它的做法是：把 Chromium 内核（就是 Chrome 浏览器的核心）嵌入到你的 Flutter 应用中，通过一块"共享纹理"把网页画面贴到 Flutter 界面上。
+
+> **比喻**：Flutter 是一个画框，Chromium 是一台藏在画框后面的微型电视机。你看不到电视机，但电视机播放的画面被实时投射到画框上。
+
+---
+
+## 四层结构，各干各的
+
+项目分了四层，从上到下依次是：
+
+```
+第 1 层：Dart（你写的 Flutter 代码）
+    ↓ 通过 MethodChannel 传话
+第 2 层：平台适配（macOS 用 ObjC，Windows 用 C++，Linux 用 C）
+    ↓ 把 Flutter 的话翻译成 C++ 能听懂的
+第 3 层：通用 C++（核心逻辑，所有平台共享）
+    ↓ 调 CEF 的 API
+第 4 层：CEF（Chromium 内核，渲染网页）
+```
+
+**为什么分这么多层？** 因为你要支持 4 个平台（macOS / Windows / Linux / eLinux），但核心逻辑不想写 4 遍。所以把"跟平台无关的逻辑"抽到第 3 层，每个平台只写自己的"翻译层"（第 2 层）。
+
+> **举例**：Dart 调用 `loadUrl("https://example.com")`，第 2 层（比如 macOS）把参数从 Flutter 的 `EncodableValue` 翻译成 C++ 的 `WValue`，然后交给第 3 层；第 3 层调 CEF 的 `LoadURL()`。Linux 的第 2 层代码不同，但它交给第 3 层的是同样的调用。
+
+---
+
+## WebView 是怎么"贴"到 Flutter 界面上的？
+
+这是整个项目最巧妙的地方。
+
+CEF 渲染网页后，会产生一张"像素图"（帧）。问题是：怎么把这张图放到 Flutter widget 树里？
+
+答案：**Flutter Texture**。Flutter 允许你把一个"纹理 ID"当作 widget 来显示，纹理的内容由原生代码（C++/ObjC）来填充。
+
+```
+Flutter 侧                        原生侧（C++/CEF）
+────────                         ────────────────
+Texture(textureId: 42)   ←──    CEF 渲染完一帧
+  ↑                              ↓
+  显示在界面上                   onPaint() / onAcceleratedPaint()
+                                ↓
+                              把像素数据塞进 textureId=42
+                              ↓
+                              通知 Flutter："有新画面了！"
+```
+
+**两种塞数据的方式：**
+
+1. **软件方式**（所有平台都支持）：CEF 把像素数据（BGRA 格式）拷贝到一块内存，然后传给 Flutter。慢，因为数据在 CPU 来回复制。
+2. **GPU 方式**（仅 macOS 和 Windows）：CEF 把 GPU 纹理句柄直接传给 Flutter，Flutter 的 GPU 直接读取。快，因为数据只在 GPU 里打转，不走 CPU。
+
+> **举例（GPU 方式，macOS）**：CEF 产生一帧画面，存为一个"IOSurface"（macOS 的 GPU 内存块）。Flutter 插件把这个 IOSurface 的内容用 Metal 快速拷贝到自己的 CVPixelBuffer 里，然后告诉 Flutter："第 42 号纹理有新帧了"。Flutter 下一帧就画出来。整个过程数据没出过 GPU。
+
+---
+
+## 网页里的 JS 怎么和 Flutter 通信？（JSBridge）
+
+这是整个项目最复杂的部分。我来用大白话讲清楚。
+
+### 场景
+
+你在网页里有个按钮，用户点击后，你希望 Flutter 层知道这件事，处理后返回结果。
+
+```
+网页 JS 代码                    Flutter Dart 代码
+───────────                    ────────────────
+Print.postMessage("hello")  →  收到 "hello"
+                            ←  返回 "world"
+收到 "world"
+```
+
+### 整个过程就像一个快递系统
+
+**第一步：注册快递站（V8 扩展）**
+
+CEF 使用的 JavaScript 引擎叫 V8（和 Chrome 一样）。在 V8 里，你可以注册"原生函数"——JS 调了一个函数，实际执行的是 C++ 代码。
+
+项目在启动时（`OnWebKitInitialized`）往每个网页里注入了一段 JS，创建了一个叫 `external` 的全局对象。这个对象的方法（如 `external.StartRequest`）就是"原生函数"——JS 调它，实际跑的是 C++。
+
+**第二步：创建快递通道（setJavaScriptChannels）**
+
+当 Flutter 这边说"我要监听一个叫 Print 的通道"，C++ 层就往网页里塞一段 JS：
+
+```javascript
+Print = {
+    postMessage: function(msg, callback) {
+        external.JavaScriptChannel('Print', msg, callback);
+    }
+};
+```
+
+这样网页里就能用 `Print.postMessage("hello")` 发送消息了。
+
+**第三步：跨进程送快递（SendProcessMessage）**
+
+等一下，有个问题。Chromium 是多进程架构：渲染网页的进程（Renderer）和主控进程（Browser）是分开的（为了安全，一个网页崩溃不会搞死整个应用）。JS 活在 Renderer 进程，Flutter 的 MethodChannel 在 Browser 进程。它们之间怎么传消息？
+
+答案：**CEF 的跨进程消息**（`SendProcessMessage`）。这是 Chromium 内核提供的"内部邮差"。
+
+```
+网 页 JS                    Renderer 进程                  Browser 进程              Flutter Dart
+────────                   ─────────────                 ────────────              ────────────
+Print.postMessage("hello")
+  → external.JavaScriptChannel('Print', 'hello')
+    → external.StartRequest(1001, 'Print', '', 'hello')
+      → [V8 原生函数]
+        → CefJSHandler::Execute("StartRequest")
+          → CefJSBridge::StartRequest()
+            → SendProcessMessage(PID_BROWSER)  ← 快递发出！
+                                                  → WebviewHandler 收到
+                                                    → onJavaScriptChannelMessage
+                                                      → MethodChannel   ← 到了！
+                                                        → Dart callback 收到 "hello"
+```
+
+**第四步：如果有回调**（请求-响应模式）
+
+如果 JS 传了回调函数：
+```javascript
+Print.postMessage("hello", function(err, reply) {
+    console.log("Flutter 回复:", reply);
+});
+```
+
+那 C++ 层会把回调函数存起来（打个标记，比如 `_1738000000_1234`），然后 Dart 处理完后调用 `sendJavaScriptChannelCallBack`，C++ 再通过 `ExecuteJavaScript` 回调掉那个标记对应的函数。整个过程是异步的——JS 发完消息继续往下跑，回调是后面触发的。
+
+> **关键点**：reqId 必须是负数。因为有两个并行的调用路径（`jsCmd` 和 `JavaScriptChannel`），用正负号区分：负数是通道消息，正数是直接函数调用。回调时通过符号判断该用哪种方式执行。
+
+---
+
+## 键盘和输入是怎么处理的？
+
+这也是一个有意思的问题。你在 Flutter 的 WebView 上打字，按键事件要经过谁？
+
+**答案：四个平台，四种方式。**
+
+### macOS
+
+macOS 通过 `NSEvent` 全局监视器拦截所有按键，然后判断：
+- 如果当前焦点在网页的**可编辑区域**（输入框、富文本编辑器），并且按的是**普通字符键** → 把事件交给 Flutter IME 处理（DeltaTextInput），最终通过 `imeSetComposition` / `imeCommitText` 传给 CEF。
+- 如果是快捷键（Cmd+C、方向键等）→ 直接发 `CefKeyEvent` 给 CEF。
+
+> **举例**：在网页输入框里打中文，按拼音字母键 → Flutter IME 处理 → 组合成候选词 → 用户选词 → `imeCommitText` 把最终文本给 CEF。但按 `Cmd+C` 复制 → 直接给 CEF 处理。
+
+### Windows
+
+Windows **不用** Flutter 的 IME 管道。它直接拦截 `WM_IME_*` 消息（Windows 原生的输入法消息），通过 `ImmGetCompositionStringW` 读取输入法内容，调 `imeSetCompositionNative` 给 CEF。
+
+> **为什么这样做？** 因为 Windows 的 IME 系统和 Flutter 的 TextInput 框架不太兼容。直接走原生管道更可靠。
+
+### Linux（GTK）
+
+通过 GTK 的 `key-press-event` 信号处理，把 GDK 键码翻译成 Windows 虚拟键码（因为 CEF 的键盘 API 用的是 Windows 键码体系）。
+
+### eLinux（嵌入式 Linux）
+
+没有 GTK，没有原生 IME。键盘事件全部由 Dart 侧的 `onKeyEvent` 处理——Flutter 的 KeyEvent → 映射成 Windows 虚拟键码 → 通过 MethodChannel 发给 CEF。
+
+---
+
+## 鼠标和滚动
+
+所有平台的鼠标事件统一由 Dart 侧（`Listener` widget）采集，然后通过 MethodChannel 发给 CEF：
+
+```
+Flutter 手势                →  CEF 鼠标事件
+─────────────────              ──────────────
+手指/鼠标移动               →  SendMouseMoveEvent
+点击                        →  SendMouseClickEvent
+滚轮                        →  SendMouseWheelEvent
+```
+
+> **一个细节**：在 Windows 和 Linux 上，滚轮的 deltaY 要取反，而且要乘以 10。因为 Flutter 的滚轮速度在这些平台上偏慢，不乘 10 的话滚半天才动一点。
+
+---
+
+## 一个页面从创建到显示的全过程
+
+我们把所有知识点串起来，看一个完整的流程：
+
+```
+1. Flutter: WebviewManager().initialize()
+   → 启动 CEF 进程，设置内部消息管道
+
+2. Flutter: WebviewManager().createWebView()
+   → 创建一个 WebViewController 对象
+
+3. Flutter: controller.initialize("https://example.com")
+   → C++ 创建一个离屏渲染的 CEF 浏览器
+   → 分配一个 Flutter Texture ID（比如 42）
+
+4. Flutter: controller.webviewWidget → Texture(textureId: 42)
+   → Flutter 在界面上显示这个纹理
+
+5. CEF 开始加载网页，渲染第一帧
+   → onAcceleratedPaint（GPU）或 onPaint（软件）
+   → 把像素给 textureId=42
+   → Flutter 界面更新，用户看到网页
+
+6. 用户在网页上操作
+   → 鼠标 → Listener → MethodChannel → CEF
+   → 键盘 → NSEvent/WM_KEY/GTK → CEF
+   → JS: Print.postMessage("hello") → ... → Dart callback
+   → Dart: evaluateJavascript("1+1") → ... → 返回 2
+```
+
+---
+
+## 总结：记住这几点就够了
+
+| 概念 | 一句话 |
+|------|--------|
+| 渲染 | CEF 把网页画到一块共享纹理上，Flutter 的 `Texture` widget 直接显示 |
+| JSBridge | JS 通过 V8 原生函数发消息 → 跨进程递给 Browser 进程 → MethodChannel 到 Dart |
+| 跨进程 | `frame->SendProcessMessage(PID_BROWSER)` 是 Renderer 和 Browser 之间的邮差 |
+| 回调 reqId | 负数 = JavaScriptChannel 消息，正数 = jsCmd 调用，通过符号分发 |
+| 键盘 | macOS 走 Flutter IME，Windows 走原生 WM_IME，Linux 用 GTK，eLinux 用 Dart |
+| 平台适配 | 通用 C++ 逻辑在 `common/`，每个平台有自己的翻译层 |
+| 单例 | `WebviewManager` 是单例，因为整个应用共用一个 CEF 进程 |

--- a/docs/chapter/0-白话理解.md
+++ b/docs/chapter/0-白话理解.md
@@ -70,7 +70,7 @@ Texture(textureId: 42)   ←──    CEF 渲染完一帧
 ```
 网页 JS 代码                    Flutter Dart 代码
 ───────────                    ────────────────
-Print.postMessage("hello")  →  收到 "hello"
+$cef.Print.postMessage("hello")  →  收到 "hello"
                             ←  返回 "world"
 收到 "world"
 ```
@@ -81,7 +81,7 @@ Print.postMessage("hello")  →  收到 "hello"
 
 CEF 使用的 JavaScript 引擎叫 V8（和 Chrome 一样）。在 V8 里，你可以注册"原生函数"——JS 调了一个函数，实际执行的是 C++ 代码。
 
-项目在启动时（`OnWebKitInitialized`）往每个网页里注入了一段 JS，创建了一个叫 `external` 的全局对象。这个对象的方法（如 `external.StartRequest`）就是"原生函数"——JS 调它，实际跑的是 C++。
+项目在启动时（`OnWebKitInitialized`）往每个网页里注入了一段 JS，创建了一个叫 `$cef` 的全局对象。这个对象的方法（如 `$cef.StartRequest`）就是"原生函数"——JS 调它，实际跑的是 C++。
 
 **第二步：创建快递通道（setJavaScriptChannels）**
 
@@ -90,12 +90,12 @@ CEF 使用的 JavaScript 引擎叫 V8（和 Chrome 一样）。在 V8 里，你�
 ```javascript
 Print = {
     postMessage: function(msg, callback) {
-        external.JavaScriptChannel('Print', msg, callback);
+        $cef.JavaScriptChannel('Print', msg, callback);
     }
 };
 ```
 
-这样网页里就能用 `Print.postMessage("hello")` 发送消息了。
+这样网页里就能用 `$cef.Print.postMessage("hello")` 发送消息了。
 
 **第三步：跨进程送快递（SendProcessMessage）**
 
@@ -106,9 +106,9 @@ Print = {
 ```
 网 页 JS                    Renderer 进程                  Browser 进程              Flutter Dart
 ────────                   ─────────────                 ────────────              ────────────
-Print.postMessage("hello")
-  → external.JavaScriptChannel('Print', 'hello')
-    → external.StartRequest(1001, 'Print', '', 'hello')
+$cef.Print.postMessage("hello")
+  → $cef.JavaScriptChannel('Print', 'hello')
+    → $cef.StartRequest(1001, 'Print', '', 'hello')
       → [V8 原生函数]
         → CefJSHandler::Execute("StartRequest")
           → CefJSBridge::StartRequest()
@@ -123,7 +123,7 @@ Print.postMessage("hello")
 
 如果 JS 传了回调函数：
 ```javascript
-Print.postMessage("hello", function(err, reply) {
+$cef.Print.postMessage("hello", function(err, reply) {
     console.log("Flutter 回复:", reply);
 });
 ```
@@ -206,7 +206,7 @@ Flutter 手势                →  CEF 鼠标事件
 6. 用户在网页上操作
    → 鼠标 → Listener → MethodChannel → CEF
    → 键盘 → NSEvent/WM_KEY/GTK → CEF
-   → JS: Print.postMessage("hello") → ... → Dart callback
+   → JS: $cef.Print.postMessage("hello") → ... → Dart callback
    → Dart: evaluateJavascript("1+1") → ... → 返回 2
 ```
 

--- a/docs/chapter/1-架构概览.md
+++ b/docs/chapter/1-架构概览.md
@@ -8,7 +8,7 @@
 ┌──────────────────────────────────────────────────────────────────┐
 │  Dart 层 (lib/)                                                  │
 │  WebviewManager(单例)  WebViewController  WebView(Widget)        │
-│  WebviewEventsListener  JavascriptChannel  WebeViewTextInput     │
+│  WebViewEventsListener  JavascriptChannel  WebeViewTextInput     │
 └───────────────────────┬──────────────────────────────────────────┘
                         │ MethodChannel("webview_cef")
                         ▼

--- a/docs/chapter/1-架构概览.md
+++ b/docs/chapter/1-架构概览.md
@@ -1,0 +1,122 @@
+# 架构概览
+
+## 分层架构
+
+`webview_cef` 是一个 Flutter 插件，通过嵌入 CEF（Chromium Embedded Framework）内核为 macOS、Windows、Linux 和 eLinux 提供 WebView 能力。项目采用**四层架构**：
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Dart 层 (lib/)                                                  │
+│  WebviewManager(单例)  WebViewController  WebView(Widget)        │
+│  WebviewEventsListener  JavascriptChannel  WebeViewTextInput     │
+└───────────────────────┬──────────────────────────────────────────┘
+                        │ MethodChannel("webview_cef")
+                        ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  平台适配层  (macOS ObjC / Windows C++ / Linux C / eLinux C++)   │
+│  插件注册  WValue ↔ 平台值类型  纹理管理                         │
+│  原生键盘/鼠标/IME 事件捕获                                      │
+└───────────┬──────────────────────────────────────────────────────┘
+            │ setInvokeMethodFunc / HandleMethodCall
+            ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  通用 C++ 层 (common/)                                           │
+│  WebviewPlugin (方法调度、编排、回调连接)                         │
+│  WebviewHandler (CEF 客户端、渲染、事件、Cookie)                 │
+│  WebviewApp (CEF 应用生命周期、进程模型、V8 扩展)                │
+│  CefJSBridge / CefJSHandler (JS ↔ C++ ↔ Dart 桥接)               │
+│  WValue (跨平台值类型)                                            │
+└───────────┬──────────────────────────────────────────────────────┘
+            │ CEF C API
+            ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  CEF (Chromium Embedded Framework)                               │
+│  Browser 进程  /  Renderer 进程  /  GPU 进程                     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## 进程模型
+
+CEF 使用多进程架构（Chromium 内核特性）。本项目支持三种进程模式（通过 `m_uMode` 控制）：
+
+| 模式     | 值  | 行为                            |
+| -------- | --- | ------------------------------- |
+| 默认     | 0   | CEF 默认进程模型                |
+| 按站点   | 1   | 每个站点独立渲染进程，最多 8 个 |
+| 按标签页 | 2   | 每个标签页独立进程              |
+| 单进程   | 3   | 所有内容在单个进程中（调试用）  |
+
+> **"站点"是什么？** <br>在 Chromium 的进程模型中，"站点"（site）指 **scheme + 注册域名**
+> （例如 `https://example.com`）。同站点下的不同页面（如 `example.com/page1` 和
+> `example.com/page2`）共享一个渲染进程；不同站点（如 `example.com` 和 `google.com`）
+> 则使用各自的渲染进程。这种模式在**内存占用**和**进程隔离安全性**之间取得平衡。
+
+- **macOS**：默认多进程模式，通过捆绑的 CEF Helper 应用运行渲染进程。如果找不到 Helper 应用则回退到单进程模式。
+- **Windows / Linux**：标准多进程模式，CEF 自动启动子进程。
+
+## 数据流
+
+### Dart → CEF 方法调用
+
+```
+Dart: _controller.loadUrl("https://example.com")
+  │
+  ▼  MethodChannel.invokeMethod('loadUrl', [browserId, url])
+  │
+平台层解码 (WValue ← Flutter 类型)
+  │
+  ▼  WebviewPlugin::HandleMethodCall("loadUrl", args)
+  │
+  ▼  WebviewHandler::loadUrl(browserId, url)
+  │
+  ▼  CEF: browser->GetMainFrame()->LoadURL(url)
+```
+
+### CEF → Dart 事件回调
+
+```
+CEF 事件: OnAddressChange / OnTitleChange / OnPaint / OnConsoleMessage ...
+  │
+  ▼  WebviewHandler::OnAddressChange() 等回调
+  │
+  ▼  WebviewPlugin::initCallback() 中注册的 lambda
+  │
+  ▼  m_invokeFunc("urlChanged", WValue map)
+  │
+平台层编码 (WValue → Flutter 类型) → MethodChannel.invokeMethod
+  │
+  ▼  Dart: WebviewManager.methodCallhandler()
+  │
+  ▼  路由到对应 WebViewController 的 listener 回调
+```
+
+## 关键设计决策
+
+### 1. WebviewManager 单例
+
+`WebviewManager` 使用工厂单例模式，因为整个应用只需要一个 CEF 进程。它协调多个 WebView 实例的生命周期，管理全局的 MethodChannel 和事件分发。
+
+### 2. 两阶段初始化
+
+- **第一阶段**：`WebviewManager().initialize()` — 启动 CEF 进程、设置 MethodChannel handler
+- **第二阶段**：`_controller.initialize(url)` — 创建浏览器实例、分配 texture ID、创建 WebView widget
+
+### 3. WValue 跨平台值中间层
+
+`WValue` 是一个 C 兼容的引用计数聚合类型，作为 MethodChannel 编解码的中间桥梁。每个平台层只需实现 `encode/decode` 函数，而 `common/` 中的代码无需关心平台特定的类型系统。
+
+### 4. Lambda 回调绑定
+
+`WebviewPlugin::initCallback()` 将 `WebviewHandler` 的 `std::function` 回调指针连接到 `m_invokeFunc`，实现通用 C++ 代码与平台特定代码的解耦。
+
+## 核心文件索引
+
+| 文件                             | 作用                               |
+| -------------------------------- | ---------------------------------- |
+| `lib/src/webview_manager.dart`   | Dart 层入口，单例管理，事件分发    |
+| `lib/src/webview.dart`           | WebViewController + WebView widget |
+| `common/webview_plugin.h/cc`     | C++ 编排器，方法调度中枢           |
+| `common/webview_handler.h/cc`    | CEF 客户端，浏览器生命周期与渲染   |
+| `common/webview_app.h/cc`        | CEF 应用生命周期，V8 扩展注册      |
+| `common/webview_js_handler.h/cc` | JS ↔ C++ 桥接，跨进程消息          |
+| `macos/Classes/CefWrapper.mm`    | macOS 平台适配（参考实现最完整）   |

--- a/docs/chapter/10-新旧项目差异对比.md
+++ b/docs/chapter/10-新旧项目差异对比.md
@@ -1,0 +1,350 @@
+# 新旧项目差异对比
+
+本文以功能维度对齐两个仓库的实现差异：
+
+- **旧项目**（`cef_flutter`）：`cef_flutter`
+- **新项目**（`webview_cef`）：当前仓库
+
+---
+
+## 1. CEF 版本与基线
+
+| 维度 | 旧项目 | 新项目 |
+|------|--------|--------|
+| CEF 版本 | 107.1.12 | 149.0.4 |
+| Chromium 版本 | 107 | 149 |
+| C++ 标准 | C++17 | C++20 |
+| macOS 最低版本 | 10.14 | 12.0 |
+| Flutter SDK | 未记录 | ≥3.27.0 |
+| Dart SDK | 未记录 | ≥3.6.0 |
+
+**关键变化**：CEF 版本从 107 跃升到 149（跨越 42 个 Chromium 大版本），需要 C++20 编译器（涉及 `std::derived_from`、`requires`、三路比较等新特性）。
+
+---
+
+## 2. CEF 二进制管理
+
+### 2.1 文件存放位置
+
+| 组件 | 旧项目 | 新项目 |
+|------|--------|--------|
+| CEF 头文件 | `cef/mac/include/` | `macos/third/cef/include/` |
+| CEF 头文件（base） | 无独立目录 | `macos/third/cef/include/base/` |
+| 分架构库 | `cef/mac/lib/`（x86_64）<br>`cef/mac/libarm64/`（arm64） | 无分架构存放，直接 lipo 合并后输出 |
+| Framework | `macos/Frameworks/Chromium Embedded Framework.framework/` | `macos/third/cef/Chromium Embedded Framework.framework/` |
+| DLL wrapper | `macos/Frameworks/libcef_dll_wrapper.a` | `macos/third/cef/libcef_dll_wrapper.a` |
+| Helper 二进制 | Xcode 多 target 独立编译，产物在 `macos/Helper/*.app` | 单一 `cef_helper` 二进制（shell 脚本 clang++ 编译），运行时克隆为 .app |
+
+### 2.2 git 跟踪策略
+
+| 策略 | 旧项目 | 新项目 |
+|------|--------|--------|
+| CEF 头文件 | **跟踪**（`cef/mac/include/*` 在 git 中） | **不跟踪**（`macos/third/cef/*` 全部忽略） |
+| Framework | **不跟踪**（`.gitignore`: `/macos/frameworks/*`） | **不跟踪**（同） |
+| DLL wrapper | **不跟踪** | **不跟踪** |
+| CEF tarball | **不跟踪**（`*.bz2`） | **不跟踪**（`/cef_tar/*.tar.bz2`） |
+| Helper .app | 作为资源打入 pod 包（`s.resource`） | 构建时动态生成，不存于源码中 |
+
+**关键变化**：旧项目将 CEF 头文件提交到 git（约 90 个 `.h` 文件），新项目完全依赖下载脚本按需获取。这减小了仓库体积，但要求开发环境网络可访问 CEF 构建服务器（或通过 `cef_tar/` 离线构建）。
+
+### 2.3 获取方式
+
+| 步骤 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 下载 | `macos/script/download.sh`，从 `cef-builds.spotifycdn.com` 下载 minimal 发行版 | `macos/scripts/download_cef.sh`，从 `cef-builds.spotifycdn.com` 下载 standard 发行版 |
+| 触发时机 | 手动执行脚本 | `pod install` 的 `prepare_command` 自动触发 |
+| 版本管理 | 硬编码在脚本中，与实际框架版本不一致 | 统一从 `third/download.cmake` 的 `CEF_VERSION` 变量读取 |
+| 幂等性 | 无，每次清除重来 | 有，通过 `version.txt` 戳检测，已存在则跳过 |
+| 离线支持 | 无 | 支持，将 tarball 放入 `cef_tar/` 目录即可离线构建 |
+
+---
+
+## 3. CEF Helper 构建
+
+这是两个项目差异最大的部分。
+
+### 3.1 旧项目：Xcode 多 target 方案
+
+```
+macos/Cef Helper/
+  Cef Helper.xcodeproj/
+    ├── Cef Helper (主 target)
+    ├── Cef Helper (GPU) target
+    ├── Cef Helper (Plugin) target
+    └── Cef Helper (Renderer) target
+  main.cpp                          ← 独立的入口点，调用 CefExecuteProcess
+helper/
+  main.cpp                          ← 同上面类似，但链接不同
+  renderer_app.cpp / .h             ← CefRenderProcessHandler 实现
+  V8JSBridgeCallHandler.cpp / .h   ← V8 桥接
+```
+
+- **4 个 Xcode target**，每个对应一种子进程类型
+- Helper 入口 `main.cpp` 使用 `CefExecuteProcess(mainArgs, nullptr, nullptr)`（第二个参数传 nullptr，无 app）
+- 渲染进程的 JS 桥接代码在单独的 `helper/` 目录中
+- 预构建的 `.app` 包通过 `s.resource` 打入 pod 产物
+
+### 3.2 新项目：单一二进制 + 克隆方案
+
+```
+macos/scripts/
+  download_cef.sh     ← 编译 cef_helper 二进制
+  embed_cef_helpers.sh ← 构建时克隆为 5 个 .app 包
+macos/helper/
+  cef_helper_main.mm  ← 入口点，全部代码通过 #include 聚合
+  Helper.entitlements
+```
+
+- **单一 `cef_helper` 二进制**（约 6.8 MB，通用 arm64+x86_64）
+- 由 `download_cef.sh` 用 `clang++` 直接编译（不依赖 Xcode 项目）
+- `cef_helper_main.mm` 通过 `#include` 聚合所有 `common/` 源文件，**主进程和 Helper 共享完全相同的 C++ 代码**
+- 构建时 `embed_cef_helpers.sh` 将 `cef_helper` 克隆为 5 个命名 `.app`（Helper、Helper (GPU)、Helper (Plugin)、Helper (Renderer)、Helper (Alerts)），动态写入 `Info.plist`
+- 入口点调用 `CefExecuteProcess(mainArgs, app, nullptr)`（传入 `WebviewApp`）
+
+### 3.3 Helper 入口点对比
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 入口文件 | `helper/main.cpp` | `macos/helper/cef_helper_main.mm` |
+| CefExecuteProcess 参数 | `(mainArgs, nullptr, nullptr)` | `(mainArgs, app, nullptr)` |
+| CEF App | 无（nullptr） | `WebviewApp`（含 V8 扩展注册、JS 桥接） |
+| 代码复用 | Helper 和主进程代码分离 | 共享 `common/` 全部源文件 |
+
+---
+
+## 4. 代码架构与组织
+
+### 4.1 总体对比
+
+```
+旧项目:
+  lib/                    ← Dart 层（含 listener / inner / manager / utils / controller）
+  browser/                ← C++ 浏览器层（每个 CEF 接口一个文件）
+  helper/                 ← C++ Helper 层（渲染进程 V8 桥接）
+  macos/Classes/          ← ObjC 平台层（含 Browser / Flutter / Inject / Protocol / Utils 子目录）
+  cef/mac/                ← CEF SDK 头文件和分架构库
+
+新项目:
+  lib/                    ← Dart 层（简洁扁平结构）
+  common/                 ← 通用 C++ 层（全平台共享，6 对 .cc/.h）
+  macos/Classes/          ← ObjC 平台层（简洁，~6 个文件）
+  macos/third/cef/        ← CEF 下载构建产物
+  windows/                ← Windows 平台层
+  linux/                  ← Linux 平台层
+  elinux/                 ← eLinux 平台层
+```
+
+### 4.2 C++ 层拆分方式
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| C++ 代码位置 | `browser/`（仅 macOS/Windows） | `common/`（全平台共享） |
+| CEF 客户端实现 | 每个 handler 一个文件（`browser_display_handler.cpp`、`browser_life_span_handler.cpp` 等，共 ~24 个文件） | 集中在 `webview_handler.cc` 一个文件中（多继承 7 个 CEF 接口） |
+| CEF App 实现 | 分散在 `browser/` 和 `helper/` 中 | 集中在 `webview_app.cc` 中 |
+| Helper 代码 | 独立目录 `helper/`（`renderer_app.cpp` + `V8JSBridgeCallHandler.cpp`） | `macos/helper/cef_helper_main.mm` 通过 `#include` 复用 `common/` 代码 |
+| 平台值类型 | 无统一中间层 | `WValue` 作为跨平台值中间层 |
+
+### 4.3 Dart 层架构
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 入口 | `lib/cef_flutter.dart` | `lib/webview_cef.dart` |
+| 核心管理类 | `CefFlutterManager` | `WebviewManager`（单例 + ValueNotifier） |
+| 控制器 | `CefController` | `WebViewController`（ValueNotifier） |
+| Widget | `CefWidget` / `CefWidgetOSR` | `WebView`（StatefulWidget） |
+| 事件监听 | 分散的 listener 类（`CefDisplayListener`、`CefLifeSpanListener`、`CefLoadListener` 等，各继承自 interface） | 统一的 `WebViewEventsListener`（单个回调集合） |
+| 平台接口 | 使用 Pigeon 模式（`MethodChannelCefFlutter` 实现 `CefFlutterPlatform`） | 直接使用 `MethodChannel("webview_cef")` |
+| JS 通道 | 通过 `CefJavaScriptListener` | `JavascriptChannel` + `onJavascriptChannelMessage` |
+| 文件数 | ~24 个 Dart 文件 | ~10 个 Dart 文件 |
+
+### 4.4 ObjC 平台层复杂度
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 文件数 | ~24 个 `.h/.m/.mm` 文件 | ~6 个 `.h/.m/.mm` 文件 |
+| 子目录 | Browser / Flutter / Inject / Protocol / Utils | 无子目录（扁平结构） |
+| 方法调配 | 使用 Aspect 库进行 AppDelegate 方法调配 | 不使用方法调配 |
+| IME 处理 | 独立的 `CFTextInputClientOSRMac` 类 | 集成在 `CefWrapper.mm` 的事件处理中 |
+| 纹理管理 | `CFFlutterTexture` 协议 | `WebviewTextureRenderer` + Metal `CVPixelBuffer` |
+
+---
+
+## 5. 跨平台支持
+
+| 平台 | 旧项目 | 新项目 |
+|------|--------|--------|
+| macOS | ✅ | ✅ |
+| Windows | ✅ | ✅ |
+| Linux | ❌ | ✅ |
+| eLinux（嵌入式 Linux） | ❌ | ✅ |
+
+**关键变化**：新项目新增 Linux 和 eLinux 两个平台。通用 C++ 层（`common/`）的设计支撑了这一点——新平台只需实现 thin platform layer 即可接入。
+
+---
+
+## 6. 渲染管线
+
+| 维度 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 主渲染路径 | **软件渲染**：`OnPaint` 返回 BGRA 像素缓冲，CPU 逐帧拷贝 | **GPU 零拷贝**：`OnAcceleratedPaint` 返回 IOSurface/D3D11 共享纹理，零拷贝到 Flutter Texture |
+| 软件回退 | — | 保留软件路径，非 GPU 构建时自动启用 |
+| 帧驱动 | CEF 内置 60fps 定时器 | 外部帧时钟：macOS CVDisplayLink / Windows IDXGIOutput::WaitForVBlank |
+| 纹理格式转换 | 每帧 `SwapBufferFromBgraToRgba`（CPU） | GPU 路径无需格式转换，零开销 |
+| 预处理器宏 | 无 | `WEBVIEW_CEF_GPU_TEXTURE=1` 条件编译 |
+| Metal 框架 | 不依赖 | 需要 `Metal`、`CoreVideo`、`IOSurface` |
+| 状态回调 | 无 | `warnIfNoAcceleratedFrame`（5秒后诊断 GPU 路径是否可用） |
+
+---
+
+## 7. JSBridge 实现
+
+| 维度 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 桥接层 | `V8JSBridgeCallHandler`（helper 层独立类） | `CefJSHandler` + `CefJSBridge`（common 层通用类） |
+| V8 扩展注册 | 分散在 helper 中 | 集中在 `WebviewApp::OnWebKitInitialized()` |
+| JS 侧 API | `clientSdk.jsCmd()` 模式，每个通道需要 `executeJavaScript` 注入 | **Proxy 自动创建**：`$cef.Print.postMessage(msg)` 无需注入，Proxy 按需创建通道 |
+| 回调机制 | 通过 `clientSdk.jsCmd` 的 callback 参数 | `JavaScriptChannel` + `EvaluateCallback` 双通道 |
+| 跨进程消息 | `frame->SendProcessMessage(PID_BROWSER)` | 同 |
+| 代码行数（扩展 JS） | 分散在多个文件 | 约 130 行 JS 内嵌在 `OnWebKitInitialized` 中 |
+
+---
+
+## 8. 输入与 IME
+
+| 维度 | 旧项目 | 新项目 |
+|------|--------|--------|
+| macOS 键盘 | `EventHandler` + `NSEvent` 本地监控 | `NSEvent.addLocalMonitorForEventsMatchingMask` |
+| Windows 键盘 | 标准消息处理 | **子类化 Flutter 视图窗口**，在 `WM_IME_*` 之前拦截 |
+| IME 组合 | OSR IME 客户端的 `CFTextInputClientOSRMac` | 直接使用 `imeSetComposition` / `imeCommitText` 驱动 CEF |
+| 原生 IME | 无 | **Windows WM_IME_** 管道（`ImeSubclassProc` 子类化处理） |
+| 光标处理 | 基本 `NSCursor` 设置 | 完整 `cef_cursor_type_t` 到 `NSCursor` 映射 |
+| 拖拽 | 不支持 | `StartDragging` + `DragTargetDragEnter/Drop` |
+
+---
+
+## 9. 依赖管理
+
+| 依赖 | 旧项目 | 新项目 |
+|------|--------|--------|
+| `Aspects`（方法调配） | ✅ 需要 | ❌ 不依赖 |
+| `FlutterMacOS` | ✅ | ✅ |
+| `Metal` framework | ❌ | ✅（GPU 渲染路径） |
+| `CoreVideo` framework | ❌ | ✅（CVPixelBuffer 纹理） |
+| `IOSurface` framework | ❌ | ✅（零拷贝共享纹理） |
+| `AVFoundation` / `CoreAudio` / 等 | ✅（podspec 中声明） | ❌ |
+| 外部 ObjC 依赖 | `Aspects` | 无 |
+
+---
+
+## 10. 构建与集成
+
+### 10.1 Podspec 对比
+
+| 维度 | 旧项目（`cef_flutter.podspec`） | 新项目（`webview_cef.podspec`） |
+|------|--------------------------------|------------------------------|
+| 版本 | 0.0.1 | 0.2.3 |
+| macOS 平台要求 | 10.14 | 12.0 |
+| C++ 标准 | C++17 | C++20 |
+| 预处理器定义 | `NDEBUG=1` | `WEBVIEW_CEF_GPU_TEXTURE=1` |
+| 供应商框架 | Frameworks 中的 CEF framework | third/cef 中的 CEF framework |
+| 资源 | `Frameworks/*`, `Helper/*`, `Entitlements/*` | 无（Helper 构建时动态生成） |
+| prepare_command | 无 | `bash scripts/download_cef.sh` |
+| 外部依赖 | `Aspects` | 无 |
+| 最小系统 | 10.14 | 12.0 |
+
+### 10.2 构建流程对比
+
+**旧项目**：
+```
+手动执行 download.sh → 下载 + 构建 libcef_dll_wrapper → 手动编译 Helper .app → 
+pod install → flutter run
+```
+
+**新项目**：
+```
+pod install（自动触发 download_cef.sh）→ 下载 + 构建 wrapper + 编译 cef_helper → 
+flutter run（自动触发 embed_cef_helpers.sh 克隆 .app 包）
+```
+
+新项目流程更自动化，`pod install` 一步到位完成 CEF 的全部准备工作。
+
+### 10.3 Helper 重编检测
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 重编触发 | Xcode 项目自动检测源文件变更 | `download_cef.sh` 对 `common/*.cc/.h` 计算 SHA256 内容哈希，存入 stamp 文件，哈希不匹配则自动重编 `cef_helper` |
+| 检测粒度 | Xcode 时间戳 | 源码内容 SHA256（更可靠） |
+
+---
+
+## 11. 进程模型配置
+
+| 维度 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 进程模型设置 | 无配置，使用 CEF 默认 | Dart 层 `ProcessMode` 枚举（`processPerSite` / `processPerTab` / `singleProcess`） |
+| 传递给原生层 | 无 | 通过 `initialize({processMode: ...})` → `init` channel → `app->SetProcessMode()` |
+| 单进程回退 | 无自动检测 | macOS 未找到 Helper 时自动回退到单进程模式 |
+
+---
+
+## 12. 缓存隔离
+
+| 维度 | 旧项目 | 新项目 |
+|------|--------|--------|
+| CEF 缓存路径 | 未设置，使用 CEF 默认路径 | 设置 `CefSettings.root_cache_path`，各平台自动推导唯一路径 |
+| Dart 层控制 | 无 | `initialize({cachePath: ...})` 可显式覆盖 |
+| 平台默认值 | — | macOS: `~/Library/Caches/<bundle_id>/cef`<br>Windows: `%LOCALAPPDATA%\<exe_name>\cef`<br>Linux: `$XDG_CACHE_HOME/<exe_name>/cef` |
+| 多实例共存 | 可能冲突（共享默认缓存目录） | 支持（独立缓存路径） |
+
+---
+
+## 13. 其他差异
+
+### 13.1 生命周期管理
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| CEF 初始化时机 | 手动调用 | `WebviewManager().initialize()`，后续调用是 no-op |
+| 退出 | 无统一入口 | `quit()` 方法调用 `stopCEF()` |
+| 浏览器销毁 | `closeBrowser` | `closeBrowser` + 纹理清理 + 插件计数归零时自动 `stopCEF()` |
+| 两阶段初始化 | 无 | 第一阶段：`initialize()` 启动 CEF；第二阶段：`controller.initialize()` 创建浏览器 |
+
+### 13.2 导航与页面事件
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 导航拦截 | 通过 `CefRequestListener` | `onBeforeBrowseCallback` → Dart `onNavigateRequest` |
+| 页面加载进度 | 无 | `OnLoadingProgressChange` → `onProgressUpdated(0.0~1.0)` |
+| 页面加载错误 | 无 | `OnLoadError` → `onPageFailed` + `WebViewError` |
+| 时序保证 | 无 | 所有页面事件回调在 WebViewController 初始化完成后触发 |
+
+### 13.3 Cookie API
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| setCookie | ✅ | ✅ |
+| deleteCookie | 无 | ✅ |
+| visitAllCookies | 无 | ✅ |
+| visitUrlCookies | 无 | ✅ |
+
+### 13.4 DevTools
+
+| 方面 | 旧项目 | 新项目 |
+|------|--------|--------|
+| 打开 DevTools | 无 | `controller.openDevTools()` |
+
+---
+
+## 总结
+
+新项目相比旧项目的主要改进方向：
+
+1. **CEF 版本升级**：107 → 149，获得 42 个大版本的 Chromium 安全更新、Web 标准支持和性能优化
+2. **平台扩展**：从 2 平台（macOS + Windows）扩展到 4 平台（+ Linux + eLinux）
+3. **GPU 零拷贝渲染**：从 CPU 软件渲染升级到 Metal/D3D11 共享纹理，显著降低帧延迟和 CPU 占用
+4. **代码简化**：C++ 文件数从 ~24 降至 6 对 `common/` 源文件；Dart 文件数从 ~24 降至 ~10
+5. **自动化构建**：`pod install` 一键完成 CEF 下载、包装器编译、Helper 编译；Helper `.app` 构建时动态生成
+6. **更好的可配置性**：Dart 层暴露进程模型、缓存路径、UserAgent 等配置
+7. **JSBridge 改进**：Proxy 自动创建通道替代手工注入，新页面直接可用无需等待注入
+8. **更完整的 WebView API**：加载进度、错误回调、DevTools、Cookie 全操作等
+9. **更可靠的健壮性**：空指针检查、错误回调、缓存隔离、纹理状态诊断

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -101,7 +101,7 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 
 | 方法 | 说明 |
 |------|------|
-| `initialize(String url)` | 创建底层 CEF 浏览器，获取 browserId 和 textureId |
+| `initialize({String url = "about:blank"})` | 创建底层 CEF 浏览器，获取 browserId 和 textureId，完成后 `value` 变为 `true` |
 | `loadUrl(String url)` | 加载指定 URL |
 | `reload()` | 刷新当前页面 |
 | `goBack()` / `goForward()` | 前进/后退 |
@@ -206,6 +206,8 @@ WebViewEventsListener(
   onPageFailed: (WebViewController controller, String url, WebViewError error) {},
 )
 ```
+
+> **时序保证**：所有页面事件回调（`onPageStarted`、`onPageFinished`、`onNavigateRequest`、`onProgressUpdated`、`onPageFailed`）均在 `WebViewController` 初始化完成后触发，回调内可安全调用 `getTitle()`、`loadUrl()` 等 API。
 
 ### 回调说明
 

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -318,4 +318,4 @@ $cef.Print.postMessage(JSON.stringify({msg: 'hello'}), function(err, res) {
 
 **文件**：`lib/src/webview_tooltip.dart`
 
-基于 Flutter Overlay 系统的 tooltip 实现。状态机：`hide → prepare（500ms 延迟）→ shown`。
+基于 Flutter Overlay 系统的 tooltip 实现。状态机：`hide → prepare（500ms 延迟）→ shown`，`shown` 状态收到新文本时拆除旧浮层重建。页面导航（`onLoadStart`）时主动清除 tooltip，兜底 CEF 不发送空 `OnTooltip` 的情况。

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -43,7 +43,7 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 
 | 方法 | 说明 |
 |------|------|
-| `initialize({String? userAgent})` | 启动 CEF 进程，设置 `methodCallhandler`，等待 300ms 确保初始化完成 |
+| `initialize({String? userAgent, ProcessMode processMode = ProcessMode.processPerSite})` | 启动 CEF 进程，设置 `methodCallhandler`，等待 300ms 确保初始化完成 |
 | `createWebView({Widget? loading, InjectUserScripts? injectUserScripts})` | 创建 WebViewController，暂存到 `_tempWebViews` |
 | `onBrowserCreated(browserIndex, browserId)` | CEF 浏览器创建完成后，将 controller 从临时表迁至 `_webViews` |
 | `dispose()` | 清理 channel handler 和 webview 映射 |
@@ -78,6 +78,18 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 | `deleteCookie(domain, key)` | 删除 Cookie |
 | `visitAllCookies()` | 遍历所有 Cookie，返回 `Map<String, Map<String, String>>` |
 | `visitUrlCookies(domain, isHttpOnly)` | 遍历指定域名的 Cookie |
+
+### ProcessMode 枚举
+
+通过 `initialize()` 的 `processMode` 参数控制 CEF 进程模型：
+
+| 枚举值 | 含义 | 进程数 | 适用场景 |
+|--------|------|--------|----------|
+| `ProcessMode.processPerSite` | 按站点隔离（默认） | ~5-8 | 生产环境、加载任意网页 |
+| `ProcessMode.processPerTab` | 按标签隔离 | 更多 | 需要最大隔离 |
+| `ProcessMode.singleProcess` | 单进程 | ~1 | 调试、嵌入式/Kiosk、受信内容 |
+
+> **注意**：单进程模式下无沙箱隔离，渲染进程崩溃会导致整个应用退出，不建议用于加载不受信第三方页面。
 
 ---
 

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -104,6 +104,7 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 | `loadUrl(String url)` | 加载指定 URL |
 | `reload()` | 刷新当前页面 |
 | `goBack()` / `goForward()` | 前进/后退 |
+| `canGoBack()` / `canGoForward()` | 查询是否有前进/后退历史，返回 `Future<bool>` |
 | `openDevTools()` | 打开 Chrome DevTools |
 
 ### JavaScript

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -43,7 +43,7 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 
 | 方法 | 说明 |
 |------|------|
-| `initialize({String? userAgent, ProcessMode processMode = ProcessMode.processPerSite})` | 启动 CEF 进程，设置 `methodCallhandler`，等待 300ms 确保初始化完成 |
+| `initialize({String? userAgent, ProcessMode processMode = ProcessMode.processPerSite, String? cachePath})` | 启动 CEF 进程，设置 `methodCallhandler`，等待 300ms 确保初始化完成 |
 | `createWebView({Widget? loading, InjectUserScripts? injectUserScripts})` | 创建 WebViewController，暂存到 `_tempWebViews` |
 | `onBrowserCreated(browserIndex, browserId)` | CEF 浏览器创建完成后，将 controller 从临时表迁至 `_webViews` |
 | `dispose()` | 清理 channel handler 和 webview 映射 |
@@ -90,6 +90,25 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 | `ProcessMode.singleProcess` | 单进程 | ~1 | 调试、嵌入式/Kiosk、受信内容 |
 
 > **注意**：单进程模式下无沙箱隔离，渲染进程崩溃会导致整个应用退出，不建议用于加载不受信第三方页面。
+
+### cachePath 参数
+
+通过 `initialize()` 的 `cachePath` 参数为 CEF 指定独立的缓存目录：
+
+| 行为 | 说明 |
+|------|------|
+| 显式指定 | `initialize(cachePath: "/path/to/cache")`，CEF 使用该目录 |
+| 不指定 | 各平台自动推导唯一路径（见下表），确保多个 App 实例共存时不冲突 |
+
+**各平台默认路径**：
+
+| 平台 | 默认路径 | 唯一性来源 |
+|------|---------|-----------|
+| macOS | `~/Library/Caches/<bundle_id>/cef` | Bundle Identifier |
+| Windows | `%LOCALAPPDATA%\<exe名称>\cef` | 可执行文件名 |
+| Linux / eLinux | `$XDG_CACHE_HOME/<exe名称>/cef` | `/proc/self/exe` 文件名 |
+
+> **为什么需要？** CEF 不指定 `root_cache_path` 时使用系统默认位置，多个 CEF 实例同时运行会导致缓存目录文件锁冲突，使浏览器创建失败。设置独立路径后，多个 App（如同一框架的不同项目）可同时运行。
 
 ---
 

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -64,6 +64,7 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 | `onBeforeBrowse` | listener | `WebViewEventsListener.onNavigateRequest` |
 | `onLoadingProgressChange` | listener | `WebViewEventsListener.onProgressUpdated` |
 | `onLoadError` | listener | `WebViewEventsListener.onPageFailed` |
+| `onRenderProcessTerminated` | listener | `WebViewEventsListener.onRenderProcessTerminated` |
 | `javascriptChannelMessage` | controller | `onJavascriptChannelMessage` → `JavascriptChannel.onMessageReceived` |
 | `onTooltip` | controller | `onToolTip` → `WebviewTooltip` |
 | `onCursorChanged` | controller | `onCursorChanged` → `MouseRegion` cursor |
@@ -235,6 +236,7 @@ WebViewEventsListener(
   onPageFinished: (WebViewController controller, String url) {},
   onProgressUpdated: (WebViewController controller, double progress) {},
   onPageFailed: (WebViewController controller, String url, WebViewError error) {},
+  onRenderProcessTerminated: (WebViewController controller, int status, int errorCode, String errorString) {},
 )
 ```
 
@@ -250,6 +252,7 @@ WebViewEventsListener(
 | `onPageFinished` | `PageFinishedCallback` | `OnLoadEnd` | 页面加载完成 |
 | `onProgressUpdated` | `PageProgressCallback` | `OnLoadingProgressChange` | 加载进度 0.0–1.0 |
 | `onPageFailed` | `PageErrorCallback` | `OnLoadError` | 加载失败，携带 `WebViewError` |
+| `onRenderProcessTerminated` | `RenderProcessTerminatedCallback` | `OnRenderProcessTerminated` | 渲染进程异常终止（崩溃、OOM、被杀），可调用 `reload()` 恢复 |
 
 ### 辅助类型
 

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -1,0 +1,264 @@
+# Dart 层 API 参考
+
+## 概述
+
+Dart 层通过 `lib/` 下的类对外暴露声明式、响应式的 WebView API。所有与原生层的通信通过 `MethodChannel("webview_cef")` 完成。
+
+## 类关系图
+
+```
+WebviewManager (单例, ValueNotifier<bool>)
+  │
+  ├── createWebView() ──► WebViewController (ValueNotifier<bool>)
+  │                         │
+  │                         ├── webviewWidget ──► WebView (StatefulWidget)
+  │                         │                      │
+  │                         │                      └── WebViewState
+  │                         │                           + WebeViewTextInput (mixin)
+  │                         │
+  │                         ├── setWebviewListener() ──► WebviewEventsListener
+  │                         ├── setJavaScriptChannels() ──► Set<JavascriptChannel>
+  │                         └── executeJavaScript() / evaluateJavascript()
+  │
+  ├── methodCallhandler() ── 事件分发到对应 controller.listener
+  ├── Cookie API: setCookie / deleteCookie / visitAllCookies
+  └── quit() ── 关闭 CEF
+```
+
+---
+
+## WebviewManager
+
+**文件**：`lib/src/webview_manager.dart`
+
+单例，继承 `ValueNotifier<bool>`。通过 `WebviewManager()` 获取实例。
+
+### 生命周期
+
+```
+initialize() → createWebView() → [使用中] → dispose() / quit()
+```
+
+### 核心方法
+
+| 方法 | 说明 |
+|------|------|
+| `initialize({String? userAgent})` | 启动 CEF 进程，设置 `methodCallhandler`，等待 300ms 确保初始化完成 |
+| `createWebView({Widget? loading, InjectUserScripts? injectUserScripts})` | 创建 WebViewController，暂存到 `_tempWebViews` |
+| `onBrowserCreated(browserIndex, browserId)` | CEF 浏览器创建完成后，将 controller 从临时表迁至 `_webViews` |
+| `dispose()` | 清理 channel handler 和 webview 映射 |
+| `quit()` | 关闭整个 CEF 进程（退出应用前调用） |
+
+### 事件分发
+
+`methodCallhandler(MethodCall call)` 处理来自原生端的所有事件回调。事件通过**两条路径**路由：
+
+- **WebviewEventsListener**（用户通过 `setWebviewListener` 注册）：页面生命周期和导航事件
+- **WebViewController 直接回调**：JS 通道、输入、焦点等内部事件
+
+| 方法名 | 路由路径 | 终点 |
+|--------|----------|------|
+| `urlChanged` | listener | `WebviewEventsListener.onUrlChanged` |
+| `titleChanged` | listener | `WebviewEventsListener.onTitleChanged` |
+| `onConsoleMessage` | listener | `WebviewEventsListener.onConsoleMessage` |
+| `onLoadStart` | listener | `WebviewEventsListener.onLoadStart` + 注入 LOAD_START 脚本 |
+| `onLoadEnd` | listener | `WebviewEventsListener.onLoadEnd` + 注入 LOAD_END 脚本 |
+| `javascriptChannelMessage` | controller | `onJavascriptChannelMessage` → `JavascriptChannel.onMessageReceived` |
+| `onTooltip` | controller | `onToolTip` → `WebviewTooltip` |
+| `onCursorChanged` | controller | `onCursorChanged` → `MouseRegion` cursor |
+| `onFocusedNodeChangeMessage` | controller | `onFocusedNodeChangeMessage` → IME attach/detach |
+| `onImeCompositionRangeChangedMessage` | controller | `onImeCompositionRangeChangedMessage` → IME 候选窗口位置 |
+
+### Cookie API
+
+| 方法 | 说明 |
+|------|------|
+| `setCookie(domain, key, value)` | 设置 Cookie |
+| `deleteCookie(domain, key)` | 删除 Cookie |
+| `visitAllCookies()` | 遍历所有 Cookie，返回 `Map<String, Map<String, String>>` |
+| `visitUrlCookies(domain, isHttpOnly)` | 遍历指定域名的 Cookie |
+
+---
+
+## WebViewController
+
+**文件**：`lib/src/webview.dart`（第 34-309 行）
+
+每个 WebView 实例对应一个 `WebViewController`，继承 `ValueNotifier<bool>`。当 `webviewWidget` 就绪时 `value` 变为 `true`。
+
+### 核心属性
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `ready` | `Future<void>` | 浏览器创建完成后的 Completer |
+| `webviewWidget` | `Widget` | 用于嵌入 widget 树的 WebView 组件 |
+| `loadingWidget` | `Widget` | 加载前显示的占位组件 |
+| `_browserId` | `int` | CEF 浏览器标识符 |
+| `_textureId` | `int` | Flutter Texture id |
+
+### 导航
+
+| 方法 | 说明 |
+|------|------|
+| `initialize(String url)` | 创建底层 CEF 浏览器，获取 browserId 和 textureId |
+| `loadUrl(String url)` | 加载指定 URL |
+| `reload()` | 刷新当前页面 |
+| `goBack()` / `goForward()` | 前进/后退 |
+| `openDevTools()` | 打开 Chrome DevTools |
+
+### JavaScript
+
+| 方法 | 说明 |
+|------|------|
+| `executeJavaScript(String code)` | 在页面中执行 JS 代码（无返回值） |
+| `evaluateJavascript(String code)` | 执行 JS 代码并返回 `Future<dynamic>` |
+| `setJavaScriptChannels(Set<JavascriptChannel>)` | 注册 JS ↔ Dart 通信通道 |
+| `sendJavaScriptChannelCallBack(error, result, callbackId, frameId)` | 回复 JS 端的回调请求 |
+
+### 输入（内部方法，由 WebView widget 调用）
+
+| 方法 | 说明 |
+|------|------|
+| `_cursorMove(Offset)` | 鼠标悬停 |
+| `_cursorClickDown(Offset)` / `_cursorClickUp(Offset)` | 鼠标按下/释放 |
+| `_cursorDragging(Offset)` | 拖拽 |
+| `_setScrollDelta(Offset, dx, dy)` | 滚轮/触控板滚动 |
+| `_setSize(dpi, Size)` | 表面尺寸变化 |
+| `sendKeyEvent(...)` | 键盘事件（eLinux 平台使用） |
+
+### IME
+
+| 方法 | 说明 |
+|------|------|
+| `imeSetComposition(text)` | 设置正在编辑的文本 |
+| `imeCommitText(text)` | 提交确认的文本 |
+| `setClientFocus(bool focus)` | 设置 CEF 浏览器焦点 |
+
+---
+
+## WebView Widget
+
+**文件**：`lib/src/webview.dart`（第 311 行起）
+
+### Widget 树结构
+
+```
+Focus (焦点管理, autofocus: true)
+  └── SizedBox.expand(key)
+      └── SizeChangedLayoutNotifier (尺寸变化通知)
+          └── Listener (指针事件采集)
+              ├── onPointerHover  → cursorMove
+              ├── onPointerDown   → cursorClickDown + 焦点请求
+              ├── onPointerUp     → cursorClickUp
+              ├── onPointerMove   → cursorDragging
+              ├── onPointerSignal → setScrollDelta (滚动)
+              └── onPointerPanZoomUpdate → setScrollDelta
+              └── MouseRegion (光标类型显示)
+                  └── Texture(textureId: controller._textureId)
+```
+
+### 焦点管理
+
+`Focus` widget 的 `onFocusChange` 回调：
+- **获得焦点**：`setClientFocus(true)`，如果当前可编辑则 `attachTextInputClient()`
+- **失去焦点**：`setClientFocus(false)`，`detachTextInputClient()`
+
+### IME Delta 处理（updateEditingValueWithDeltas）
+
+此方法是 `DeltaTextInputClient` 接口的实现，定义在 `WebViewState` 中（非 mixin），处理组合输入：
+
+| Delta 类型 | 处理方式 |
+|-----------|---------|
+| `TextEditingDeltaInsertion` | 组合中 → `imeSetComposition`；直接提交 → `imeCommitText` |
+| `TextEditingDeltaDeletion` | 组合中 → `imeSetComposition` |
+| `TextEditingDeltaReplacement` | 组合中 → 更新 composition；结束 → `imeCommitText` |
+| `TextEditingDeltaNonTextUpdate` | 清空 composition → `imeCommitText` |
+
+### 键盘处理（eLinux）
+
+当 `hasNativeKeySupport == false` 时，通过 `_onKeyEvent()` 处理：
+1. 将 Flutter `LogicalKeyboardKey` 映射为 Windows 虚拟键码
+2. 构建 CEF 修饰键标志
+3. 发送 `KEYEVENT_RAWKEYDOWN`（有字符时附带 `KEYEVENT_CHAR`）
+
+---
+
+## WebviewEventsListener
+
+**文件**：`lib/src/webview_events_listener.dart`
+
+可选回调接口：
+
+```dart
+WebviewEventsListener({
+  onTitleChanged: (String title) {},
+  onUrlChanged: (String url) {},
+  onConsoleMessage: (int level, String message, String source, int line) {},
+  onLoadStart: (WebViewController controller, String url) {},
+  onLoadEnd: (WebViewController controller, String url) {},
+})
+```
+
+---
+
+## JavascriptChannel / JavascriptMessage
+
+**文件**：`lib/src/webview_javascript.dart`
+
+```dart
+JavascriptChannel(
+  name: 'Print',                              // 通道名，匹配 JS 侧的 window.Print
+  onMessageReceived: (JavascriptMessage msg) {
+    print(msg.message);                       // JS 传来的 payload
+    // 回复 JS 回调
+    controller.sendJavaScriptChannelCallBack(
+      false,                                  // error=false 表示成功
+      "{'code': '200'}",                      // 返回结果
+      msg.callbackId,
+      msg.frameId,
+    );
+  },
+)
+```
+
+**JS 侧调用方式**（由 `setJavaScriptChannels` 注入）：
+
+```javascript
+// 只发送消息
+Print.postMessage(JSON.stringify({msg: 'hello'}));
+
+// 发送消息并接收回调
+Print.postMessage(JSON.stringify({msg: 'hello'}), function(err, res) {
+  console.log('reply:', res);
+});
+```
+
+---
+
+## WebeViewTextInput Mixin
+
+**文件**：`lib/src/webview_textinput.dart`
+
+`DeltaTextInputClient` mixin，提供 IME 输入连接的基础设施：
+
+- `attachTextInputClient()` — 建立 `TextInputConnection`（Windows 上跳过，因为 Windows 通过原生 WM_IME 管道处理）
+- `detachTextInputClient()` — 关闭连接
+- `updateIMEComposionPosition(x, y, height, offset)` — 设置 IME 候选窗口的变换矩阵
+
+> `updateEditingValueWithDeltas` 是 `DeltaTextInputClient` 接口方法，由 `WebViewState` 直接 override 实现（见上文 WebView Widget 部分），不在 mixin 中。
+
+---
+
+## 其他工具类
+
+### InjectUserScripts / UserScript
+
+**文件**：`lib/src/webview_inject_user_script.dart`
+
+在 `LOAD_START` 或 `LOAD_END` 时注入的脚本，通过 `executeJavaScript` 执行。
+
+### WebviewTooltip
+
+**文件**：`lib/src/webview_tooltip.dart`
+
+基于 Flutter Overlay 系统的 tooltip 实现。状态机：`hide → prepare（500ms 延迟）→ shown`。

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -16,7 +16,7 @@ WebviewManager (单例, ValueNotifier<bool>)
   │                         │                      └── WebViewState
   │                         │                           + WebeViewTextInput (mixin)
   │                         │
-  │                         ├── setWebviewListener() ──► WebviewEventsListener
+  │                         ├── setWebviewListener() ──► WebViewEventsListener
   │                         ├── setJavaScriptChannels() ──► Set<JavascriptChannel>
   │                         └── executeJavaScript() / evaluateJavascript()
   │
@@ -53,16 +53,17 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 
 `methodCallhandler(MethodCall call)` 处理来自原生端的所有事件回调。事件通过**两条路径**路由：
 
-- **WebviewEventsListener**（用户通过 `setWebviewListener` 注册）：页面生命周期和导航事件
+- **WebViewEventsListener**（用户通过 `setWebviewListener` 注册）：页面生命周期和导航事件
 - **WebViewController 直接回调**：JS 通道、输入、焦点等内部事件
 
 | 方法名 | 路由路径 | 终点 |
 |--------|----------|------|
-| `urlChanged` | listener | `WebviewEventsListener.onUrlChanged` |
-| `titleChanged` | listener | `WebviewEventsListener.onTitleChanged` |
-| `onConsoleMessage` | listener | `WebviewEventsListener.onConsoleMessage` |
-| `onLoadStart` | listener | `WebviewEventsListener.onLoadStart` + 注入 LOAD_START 脚本 |
-| `onLoadEnd` | listener | `WebviewEventsListener.onLoadEnd` + 注入 LOAD_END 脚本 |
+| `onConsoleMessage` | listener | `WebViewEventsListener.onConsoleMessage` |
+| `onLoadStart` | listener | `WebViewEventsListener.onPageStarted` + 注入 LOAD_START 脚本 |
+| `onLoadEnd` | listener | `WebViewEventsListener.onPageFinished` + 注入 LOAD_END 脚本 |
+| `onBeforeBrowse` | listener | `WebViewEventsListener.onNavigateRequest` |
+| `onLoadingProgressChange` | listener | `WebViewEventsListener.onProgressUpdated` |
+| `onLoadError` | listener | `WebViewEventsListener.onPageFailed` |
 | `javascriptChannelMessage` | controller | `onJavascriptChannelMessage` → `JavascriptChannel.onMessageReceived` |
 | `onTooltip` | controller | `onToolTip` → `WebviewTooltip` |
 | `onCursorChanged` | controller | `onCursorChanged` → `MouseRegion` cursor |
@@ -106,6 +107,8 @@ initialize() → createWebView() → [使用中] → dispose() / quit()
 | `goBack()` / `goForward()` | 前进/后退 |
 | `canGoBack()` / `canGoForward()` | 查询是否有前进/后退历史，返回 `Future<bool>` |
 | `openDevTools()` | 打开 Chrome DevTools |
+| `stopLoading()` | 中止当前页面加载 |
+| `getTitle()` | 获取当前页面标题，返回 `Future<String?>` |
 
 ### JavaScript
 
@@ -184,21 +187,41 @@ Focus (焦点管理, autofocus: true)
 
 ---
 
-## WebviewEventsListener
+## WebViewEventsListener
 
 **文件**：`lib/src/webview_events_listener.dart`
 
-可选回调接口：
+所有回调均为可选，通过 `WebViewController.setWebviewListener()` 注册：
 
 ```dart
-WebviewEventsListener({
-  onTitleChanged: (String title) {},
-  onUrlChanged: (String url) {},
+WebViewEventsListener(
   onConsoleMessage: (int level, String message, String source, int line) {},
-  onLoadStart: (WebViewController controller, String url) {},
-  onLoadEnd: (WebViewController controller, String url) {},
-})
+  onNavigateRequest: (WebViewController controller, String url) {
+    // 返回 NavigationPolicy.cancel 以阻止导航，需调用 controller.stopLoading()
+    return NavigationPolicy.allow;
+  },
+  onPageStarted: (WebViewController controller, String url) {},
+  onPageFinished: (WebViewController controller, String url) {},
+  onProgressUpdated: (WebViewController controller, double progress) {},
+  onPageFailed: (WebViewController controller, String url, WebViewError error) {},
+)
 ```
+
+### 回调说明
+
+| 回调 | 类型 | CEF 触发源 | 说明 |
+|------|------|-----------|------|
+| `onConsoleMessage` | `PageConsoleCallback` | `OnConsoleMessage` | 页面 console 日志 |
+| `onNavigateRequest` | `PageNavigationDelegate` | `OnBeforeBrowse` | 导航拦截（返回 `cancel` + 调 `stopLoading()` 中止） |
+| `onPageStarted` | `PageStartedCallback` | `OnLoadStart` | 页面开始加载 |
+| `onPageFinished` | `PageFinishedCallback` | `OnLoadEnd` | 页面加载完成 |
+| `onProgressUpdated` | `PageProgressCallback` | `OnLoadingProgressChange` | 加载进度 0.0–1.0 |
+| `onPageFailed` | `PageErrorCallback` | `OnLoadError` | 加载失败，携带 `WebViewError` |
+
+### 辅助类型
+
+- **`NavigationPolicy`**：枚举 `cancel` / `allow`
+- **`WebViewError`**：`{ int code, String message, Map<String, dynamic>? extraInfo }`，`extraInfo["url"]` 为失败 URL
 
 ---
 

--- a/docs/chapter/2-Dart层API.md
+++ b/docs/chapter/2-Dart层API.md
@@ -249,10 +249,10 @@ JavascriptChannel(
 
 ```javascript
 // 只发送消息
-Print.postMessage(JSON.stringify({msg: 'hello'}));
+$cef.Print.postMessage(JSON.stringify({msg: 'hello'}));
 
 // 发送消息并接收回调
-Print.postMessage(JSON.stringify({msg: 'hello'}), function(err, res) {
+$cef.Print.postMessage(JSON.stringify({msg: 'hello'}), function(err, res) {
   console.log('reply:', res);
 });
 ```

--- a/docs/chapter/3-通用C++层.md
+++ b/docs/chapter/3-通用C++层.md
@@ -49,7 +49,8 @@ WebviewApp (CEF 应用)
 
 ```
 HandleMethodCall(name, args, result)
-  ├── "init"              → startCEF() + initCallback()
+  ├── "init"              → 解析 Map{processMode, userAgent} 或旧版 String 格式，
+  │                         调用 app->SetProcessMode()，然后 startCEF() + initCallback()
   ├── "create"            → createBrowser() + 纹理创建，return [browserId, textureId]
   ├── "close"             → closeBrowser()
   ├── "loadUrl"           → m_handler->loadUrl(id, url)

--- a/docs/chapter/3-通用C++层.md
+++ b/docs/chapter/3-通用C++层.md
@@ -124,7 +124,7 @@ struct browser_info {
 
 **浏览器管理**：`createBrowser(url, callback)`、`closeBrowser(id)`、`changeSize(id, dpi, w, h)`
 
-**导航**：`loadUrl(id, url)`、`goForward(id)`、`goBack(id)`、`reload(id)`、`openDevTools(id)`
+**导航**：`loadUrl(id, url)`、`goForward(id)`、`goBack(id)`、`canGoBack(id)`、`canGoForward(id)`、`reload(id)`、`openDevTools(id)`
 
 **输入**：
 - 鼠标：`cursorClick(id, x, y, up)`、`cursorMove(id, x, y, dragging)`

--- a/docs/chapter/3-通用C++层.md
+++ b/docs/chapter/3-通用C++层.md
@@ -49,7 +49,7 @@ WebviewApp (CEF 应用)
 
 ```
 HandleMethodCall(name, args, result)
-  ├── "init"              → 解析 Map{processMode, userAgent} 或旧版 String 格式，
+  ├── "init"              → 解析 Map{processMode, userAgent, cachePath} 或旧版 String 格式，
   │                         调用 app->SetProcessMode()，然后 startCEF() + initCallback()
   ├── "create"            → createBrowser() + 纹理创建，return [browserId, textureId]
   ├── "close"             → closeBrowser()
@@ -74,10 +74,11 @@ HandleMethodCall(name, args, result)
 | 函数 | 说明 |
 |------|------|
 | `initCEFProcesses(argc, argv)` | 创建 WebviewApp，调用 `CefExecuteProcess` |
-| `startCEF()` | 配置 `CefSettings`，调用 `CefInitialize` |
+| `startCEF()` | 配置 `CefSettings`（含 `root_cache_path` 以避免多实例冲突），调用 `CefInitialize` |
 | `doMessageLoopWork()` | macOS 外部消息泵，调用 `CefDoMessageLoopWork()` |
 | `SwapBufferFromBgraToRgba(src, dst, w, h)` | BGRA → RGBA 像素格式转换 |
-| `setMacCEFPaths(...)` | 设置 macOS CEF 框架路径 |
+| `setMacCEFPaths(...)` | 设置 macOS CEF 框架路径（子进程 helper、Framework 目录、Main Bundle 路径） |
+| `setCefCachePath(cachePath)` | 设置 CEF 缓存根目录。各平台 layer 会在初始化前自动调用此函数设置默认值，Dart 层可通过 `initialize(cachePath:)` 覆盖 |
 
 ---
 

--- a/docs/chapter/3-通用C++层.md
+++ b/docs/chapter/3-通用C++层.md
@@ -1,0 +1,226 @@
+# 通用 C++ 层参考
+
+## 概述
+
+`common/` 目录包含所有与平台无关的 CEF 代码，每个平台层编译并链接这些源文件。这是项目最核心、最复杂的部分。
+
+## 类关系图
+
+```
+WebviewPlugin (编排器)
+  │
+  ├── m_handler ──► WebviewHandler (CEF 客户端)
+  │                   │
+  │                   ├── browser_map_ (browserId → browser_info)
+  │                   ├── js_callbacks_ (evaluateJavascript 回调)
+  │                   ├── onUrlChangedEvent / onTitleChangedEvent ...
+  │                   └── 实现 CefClient, CefRenderHandler 等接口
+  │
+  ├── m_renderers (browserId → WebviewTexture*)
+  │
+  └── HandleMethodCall() ── 约 25 种方法的 switch 分发
+
+WebviewApp (CEF 应用)
+  │
+  ├── m_render_js_bridge ──► CefJSBridge (渲染进程侧)
+  │                           │
+  │                           ├── startRequest_callback_ (JavaScriptChannel 回调)
+  │                           └── render_callback_ (jsCmd 回调)
+  │
+  ├── OnWebKitInitialized() ── 注册 V8 扩展
+  └── CefJSHandler ── V8 native function 调度器
+```
+
+---
+
+## WebviewPlugin
+
+**文件**：`common/webview_plugin.h/cc`
+
+项目的中央编排器，负责连接所有组件。属于 `webview_cef` 命名空间。
+
+### 核心职责
+
+1. **方法调度** — `HandleMethodCall()` 将来自四个平台的 ~25 种方法调用路由到 `WebviewHandler` 或内部逻辑
+2. **回调绑定** — `initCallback()` 将 `WebviewHandler` 的回调 lambda 连接到平台层的 MethodChannel
+3. **纹理管理** — 通过 `m_createTextureFunc` 让平台层控制纹理创建，维护 `m_renderers` 映射
+
+### HandleMethodCall 关键分支
+
+```
+HandleMethodCall(name, args, result)
+  ├── "init"              → startCEF() + initCallback()
+  ├── "create"            → createBrowser() + 纹理创建，return [browserId, textureId]
+  ├── "close"             → closeBrowser()
+  ├── "loadUrl"           → m_handler->loadUrl(id, url)
+  ├── "setSize"           → m_handler->changeSize(id, dpi, w, h)
+  ├── "cursorClickDown"   → m_handler->cursorClick(id, x, y, false)
+  ├── "cursorClickUp"     → m_handler->cursorClick(id, x, y, true)
+  ├── "cursorMove"        → m_handler->cursorMove(id, x, y, dragging)
+  ├── "cursorDragging"    → m_handler->cursorMove(id, x, y, true)
+  ├── "setScrollDelta"    → m_handler->sendScrollEvent(id, x, y, dx, dy)
+  ├── "goForward" / "goBack" / "reload" / "openDevTools"
+  ├── "imeSetComposition" / "imeCommitText" / "setClientFocus"
+  ├── "setJavaScriptChannels" / "sendJavaScriptChannelCallBack"
+  ├── "executeJavaScript" / "evaluateJavascript"
+  ├── "sendKeyEvent"      → sendKeyEvent (含 Cmd+Backspace 特殊处理)
+  ├── "setCookie" / "deleteCookie" / "visitAllCookies" / "visitUrlCookies"
+  └── "hasNativeKeySupport" → 编译时确定的常量
+```
+
+### 全局函数
+
+| 函数 | 说明 |
+|------|------|
+| `initCEFProcesses(argc, argv)` | 创建 WebviewApp，调用 `CefExecuteProcess` |
+| `startCEF()` | 配置 `CefSettings`，调用 `CefInitialize` |
+| `doMessageLoopWork()` | macOS 外部消息泵，调用 `CefDoMessageLoopWork()` |
+| `SwapBufferFromBgraToRgba(src, dst, w, h)` | BGRA → RGBA 像素格式转换 |
+| `setMacCEFPaths(...)` | 设置 macOS CEF 框架路径 |
+
+---
+
+## WebviewHandler
+
+**文件**：`common/webview_handler.h/cc`
+
+继承自 `CefClient`、`CefDisplayHandler`、`CefLifeSpanHandler`、`CefFocusHandler`、
+`CefLoadHandler`、`CefRenderHandler`，共 6 个 CEF 接口。拖拽功能 `StartDragging` 由 `CefRenderHandler` 提供。
+
+### browser_info 结构
+
+```cpp
+struct browser_info {
+    CefRefPtr<CefBrowser> browser;
+    int width, height;
+    float dpi;
+    bool is_dragging;
+    bool is_ime_commit;
+    CefRect prev_ime_position;
+    bool wants_focus;
+    bool focus_reasserted;
+};
+```
+
+### 回调函数指针
+
+所有以 `std::function` 形式声明，由 `WebviewPlugin::initCallback()` 赋值：
+
+| 回调 | 触发源 |
+|------|--------|
+| `onPaintCallback` | `OnPaint` — 软件渲染帧 |
+| `onAcceleratedPaintCallback` | `OnAcceleratedPaint` — GPU 纹理帧 |
+| `onUrlChangedEvent` | `OnAddressChange` |
+| `onTitleChangedEvent` | `OnTitleChange` |
+| `onCursorChangedEvent` | `OnCursorChange` |
+| `onTooltipEvent` | `OnTooltip` |
+| `onConsoleMessageEvent` | `OnConsoleMessage` |
+| `onJavaScriptChannelMessage` | `OnProcessMessageReceived` → `kJSCallCppFunctionMessage` |
+| `onFocusedNodeChangeMessage` | `OnProcessMessageReceived` → `kFocusedNodeChangedMessage` |
+| `onImeCompositionRangeChangedMessage` | `OnImeCompositionRangeChanged` |
+| `onLoadStart` / `onLoadEnd` | `OnLoadStart` / `OnLoadEnd` |
+
+### 关键方法
+
+**浏览器管理**：`createBrowser(url, callback)`、`closeBrowser(id)`、`changeSize(id, dpi, w, h)`
+
+**导航**：`loadUrl(id, url)`、`goForward(id)`、`goBack(id)`、`reload(id)`、`openDevTools(id)`
+
+**输入**：
+- 鼠标：`cursorClick(id, x, y, up)`、`cursorMove(id, x, y, dragging)`
+- 滚动：`sendScrollEvent(id, x, y, dx, dy)`（非 macOS 平台取反 dy，非 macOS 乘 10）
+- 键盘：`sendKeyEvent(CefKeyEvent& ev)` → 当前聚焦浏览器
+- 拖拽：`StartDragging()` → `DragTargetDragEnter/Drop`
+
+**IME**：
+- `imeSetComposition(id, text)` — 来自 Flutter Delta 输入
+- `imeCommitText(id, text)` — 提交确认文本
+- `imeSetCompositionNative(text, cursor)` — Windows 原生 IME 使用
+- `imeCommitTextNative(text)` — Windows 原生 IME 使用
+
+**JavaScript**：
+- `setJavaScriptChannels(id, channels)` — 注入 `window.X = {postMessage: ...}` 代码
+- `executeJavaScript(id, code, callback?)` — 执行 JS，可选通过 `EvaluateCallback` 获取返回值
+- `sendJavaScriptChannelCallBack(error, result, callbackId, browserId, frameId)` — 向渲染进程发送回调
+
+**Cookie**：`setCookie(domain, key, value)`、`deleteCookie(domain, key)`、`visitAllCookies(callback)`、`visitUrlCookies(domain, isHttpOnly, callback)`
+
+**帧驱动**：`sendExternalBeginFrame()` — GPU 路径下驱动所有浏览器渲染
+
+---
+
+## WebviewApp
+
+**文件**：`common/webview_app.h/cc`
+
+继承 `CefApp`、`CefBrowserProcessHandler`、`CefRenderProcessHandler`。
+
+### 核心职责
+
+1. **进程类型判断** — `GetProcessType()` 通过命令行参数 `--type` 区分 Browser / Renderer / Zygote 进程
+2. **命令行配置** — `OnBeforeCommandLineProcessing()` 设置 GPU、沙箱、进程模型、跨域等开关
+3. **V8 扩展注册** — `OnWebKitInitialized()` 注入 JS ↔ C++ 桥接代码（详见 [JSBridge 详解](jsbridge-deep-dive.md)）
+4. **渲染进程消息处理** — `OnProcessMessageReceived()` 处理 `kExecuteJsCallbackMessage`
+5. **焦点节点跟踪** — `OnFocusedNodeChanged()` 向浏览器进程发送可编辑节点信息
+
+---
+
+## WValue
+
+**文件**：`common/webview_value.h/cc`
+
+跨平台值类型（C API），作为 MethodChannel 编解码的中间桥梁。
+
+### 支持的类型
+
+```
+Null, Bool, Int, Float, Double, String,
+Uint8List, Int32List, Int64List, FloatList, DoubleList,
+List, Map
+```
+
+### 核心 API
+
+```c
+// 创建（全部返回指针）
+WValue* webview_value_new_bool(bool v);
+WValue* webview_value_new_string(const char* v);
+WValue* webview_value_new_map();
+
+// 读写（全部使用指针）
+bool webview_value_get_bool(WValue* v);
+const char* webview_value_get_string(WValue* v);
+
+// 修改
+void webview_value_set(WValue* parent, WValue* key, WValue* child);   // key 为 WValue*
+void webview_value_set_string(WValue* parent, const char* key, WValue* child); // key 为 C 字符串
+void webview_value_append(WValue* parent, WValue* child);
+
+// 引用计数
+WValue* webview_value_ref(WValue* v);
+void webview_value_unref(WValue* v);
+```
+
+---
+
+## WebviewTexture（抽象基类）
+
+```cpp
+class WebviewTexture {
+public:
+    int textureId;
+    bool isFocused = false;
+    bool editableFocused = false;
+    bool composing = false;
+
+    virtual void onFrame(const void* buffer, int width, int height) = 0;
+    virtual void onAcceleratedFrame(const void* sharedHandle,
+                                    int width, int height, int format) = 0;
+};
+```
+
+每个平台实现自己的 `WebviewTexture` 子类：
+- macOS: `WebviewTextureRenderer`（CefWrapper.mm 内部类）
+- Windows: `WebviewTextureRenderer` / `WebviewGpuTextureRenderer`
+- Linux: `WebviewTextureRenderer`
+- eLinux: `WebviewTextureRenderer`

--- a/docs/chapter/3-通用C++层.md
+++ b/docs/chapter/3-通用C++层.md
@@ -125,6 +125,7 @@ struct browser_info {
 | `onBeforeBrowseCallback` | `OnBeforeBrowse`（CefRequestHandler） — 始终放行，异步通知 Dart |
 | `onLoadingProgressChangeCallback` | `OnLoadingProgressChange` — 进度 0.0–1.0 |
 | `onLoadErrorCallback` | `OnLoadError` — 通知 Dart，内置错误页已禁用 |
+| `onRenderProcessTerminated` | `OnRenderProcessTerminated` — 渲染进程异常终止（崩溃、OOM、被杀） |
 
 ### 关键方法
 

--- a/docs/chapter/3-通用C++层.md
+++ b/docs/chapter/3-通用C++层.md
@@ -135,7 +135,7 @@ struct browser_info {
 **输入**：
 - 鼠标：`cursorClick(id, x, y, up)`、`cursorMove(id, x, y, dragging)`
 - 滚动：`sendScrollEvent(id, x, y, dx, dy)`（非 macOS 平台取反 dy，非 macOS 乘 10）
-- 键盘：`sendKeyEvent(CefKeyEvent& ev)` → 当前聚焦浏览器
+- 键盘：`sendKeyEvent(CefKeyEvent& ev)` → 当前聚焦浏览器。转发前拦截 DevTools 快捷键（F12 / Cmd+Opt+I / Ctrl+Shift+I），命中则打开 DevTools 且不转发至页面
 - 拖拽：`StartDragging()` → `DragTargetDragEnter/Drop`
 
 **IME**：

--- a/docs/chapter/3-通用C++层.md
+++ b/docs/chapter/3-通用C++层.md
@@ -59,7 +59,7 @@ HandleMethodCall(name, args, result)
   ├── "cursorMove"        → m_handler->cursorMove(id, x, y, dragging)
   ├── "cursorDragging"    → m_handler->cursorMove(id, x, y, true)
   ├── "setScrollDelta"    → m_handler->sendScrollEvent(id, x, y, dx, dy)
-  ├── "goForward" / "goBack" / "reload" / "openDevTools"
+  ├── "goForward" / "goBack" / "reload" / "stopLoading" / "openDevTools" / "getTitle"
   ├── "imeSetComposition" / "imeCommitText" / "setClientFocus"
   ├── "setJavaScriptChannels" / "sendJavaScriptChannelCallBack"
   ├── "executeJavaScript" / "evaluateJavascript"
@@ -85,7 +85,7 @@ HandleMethodCall(name, args, result)
 **文件**：`common/webview_handler.h/cc`
 
 继承自 `CefClient`、`CefDisplayHandler`、`CefLifeSpanHandler`、`CefFocusHandler`、
-`CefLoadHandler`、`CefRenderHandler`，共 6 个 CEF 接口。拖拽功能 `StartDragging` 由 `CefRenderHandler` 提供。
+`CefLoadHandler`、`CefRenderHandler`、`CefRequestHandler`，共 7 个 CEF 接口。拖拽功能 `StartDragging` 由 `CefRenderHandler` 提供。
 
 ### browser_info 结构
 
@@ -95,6 +95,7 @@ struct browser_info {
     int width, height;
     float dpi;
     bool is_dragging;
+    std::string title;
     bool is_ime_commit;
     CefRect prev_ime_position;
     bool wants_focus;
@@ -119,6 +120,9 @@ struct browser_info {
 | `onFocusedNodeChangeMessage` | `OnProcessMessageReceived` → `kFocusedNodeChangedMessage` |
 | `onImeCompositionRangeChangedMessage` | `OnImeCompositionRangeChanged` |
 | `onLoadStart` / `onLoadEnd` | `OnLoadStart` / `OnLoadEnd` |
+| `onBeforeBrowseCallback` | `OnBeforeBrowse`（CefRequestHandler） — 始终放行，异步通知 Dart |
+| `onLoadingProgressChangeCallback` | `OnLoadingProgressChange` — 进度 0.0–1.0 |
+| `onLoadErrorCallback` | `OnLoadError` — 通知 Dart，内置错误页已禁用 |
 
 ### 关键方法
 

--- a/docs/chapter/4-JSBridge详解.md
+++ b/docs/chapter/4-JSBridge详解.md
@@ -6,8 +6,8 @@ JSBridge 是 `webview_cef` 中最复杂的子系统，实现 JavaScript ↔ Dart
 
 | 路径 | JS 入口 | 方向 | 特点 |
 |------|---------|------|------|
-| JavaScriptChannel（无回调） | `Print.postMessage(json)` | JS → Dart | 单向消息 |
-| JavaScriptChannel（有回调） | `Print.postMessage(json, callback)` | JS → Dart → JS | 请求-响应模式 |
+| JavaScriptChannel（无回调） | `$cef.Print.postMessage(json)` | JS → Dart | 单向消息 |
+| JavaScriptChannel（有回调） | `$cef.Print.postMessage(json, callback)` | JS → Dart → JS | 请求-响应模式 |
 | evaluateJavascript | Dart 侧调用 | Dart → JS → Dart | 执行 JS 并返回值 |
 
 涉及的关键文件：
@@ -29,16 +29,16 @@ JSBridge 是 `webview_cef` 中最复杂的子系统，实现 JavaScript ↔ Dart
 ```
 bridge.html                          setJavaScriptChannels               V8 扩展
 ──────────                           ──────────────────                  ────────
-Print.postMessage(msg [, cb]) ──►    Print.postMessage = (e,r) => {      external.JavaScriptChannel
-                                         external.JavaScriptChannel      external.StartRequest
-                                             ('Print', e, r)             external.GetNextReqID
-                                     }                                  external.EvaluateCallback
+$cef.Print.postMessage(msg [, cb]) ──►    $cef.Print.postMessage = (e,r) => {      $cef.JavaScriptChannel
+                                         $cef.JavaScriptChannel      $cef.StartRequest
+                                             ('Print', e, r)             $cef.GetNextReqID
+                                     }                                  $cef.EvaluateCallback
 ```
 
 ```
 外部 (JS)                           V8 原生函数                          C++ 渲染进程
 ───────                             ────────────                         ────────────
-external.StartRequest(...)    →     native function StartRequest()  →    CefJSHandler::Execute("StartRequest")
+$cef.StartRequest(...)    →     native function StartRequest()  →    CefJSHandler::Execute("StartRequest")
                                                                          CefJSBridge::StartRequest()
                                                                            → frame->SendProcessMessage(PID_BROWSER)
 ```
@@ -60,19 +60,19 @@ WebviewHandler::OnProcessMessageReceived
 
 **位置**：`WebviewApp::OnWebKitInitialized()` (`common/webview_app.cc`)
 
-CEF 在每个渲染进程启动时调用此方法一次。它通过 `CefRegisterExtension` 将 JS 代码注入到每个页面的 V8 上下文中，创建 `external` 和 `clientSdk` 两个全局命名空间。
+CEF 在每个渲染进程启动时调用此方法一次。它通过 `CefRegisterExtension` 将 JS 代码注入到每个页面的 V8 上下文中，创建 `$cef` 和 `clientSdk` 两个全局命名空间。
 
 注入的 JS 核心结构：
 
 ```javascript
-var external = {};
+var $cef = {};
 var clientSdk = {};
 
-// ── external.JavaScriptChannel(n, e, r) ──
+// ── $cef.JavaScriptChannel(n, e, r) ──
 // n = 通道名（如 "Print"）
 // e = 消息体（会被 JSON.stringify 序列化）
 // r = 可选回调 function(error, result)
-external.JavaScriptChannel = (n, e, r) => {
+$cef.JavaScriptChannel = (n, e, r) => {
     var a;
     // 如果传了回调，生成唯一函数名存入 window[a]，等待原生侧回调
     null == r
@@ -85,23 +85,23 @@ external.JavaScriptChannel = (n, e, r) => {
                }
            }(a, r));
     // 发送请求：reqID 取负数，以便与 jsCmd 的正数 ID 区分
-    external.StartRequest(external.GetNextReqID(), n, a, JSON.stringify(e || {}), '');
+    $cef.StartRequest($cef.GetNextReqID(), n, a, JSON.stringify(e || {}), '');
 };
 
-// ── external.StartRequest ── V8 原生函数 → CefJSHandler::Execute("StartRequest")
-external.StartRequest = (nReqID, strCmd, strCallBack, strArgs, strLog) => {
+// ── $cef.StartRequest ── V8 原生函数 → CefJSHandler::Execute("StartRequest")
+$cef.StartRequest = (nReqID, strCmd, strCallBack, strArgs, strLog) => {
     native function StartRequest();
     StartRequest(nReqID, strCmd, strCallBack, strArgs, strLog);
 };
 
-// ── external.GetNextReqID ── 原子递增的请求 ID
-external.GetNextReqID = () => {
+// ── $cef.GetNextReqID ── 原子递增的请求 ID
+$cef.GetNextReqID = () => {
     native function GetNextReqID();
     return GetNextReqID();
 };
 
-// ── external.EvaluateCallback ── evaluateJavascript 的回调出口
-external.EvaluateCallback = (nReqID, result) => {
+// ── $cef.EvaluateCallback ── evaluateJavascript 的回调出口
+$cef.EvaluateCallback = (nReqID, result) => {
     native function EvaluateCallback();
     EvaluateCallback(nReqID, result);
 };
@@ -123,7 +123,7 @@ void WebviewHandler::setJavaScriptChannels(int browserId,
     std::string extensionCode = "try{";
     for (auto& channel : channels) {
         extensionCode += channel;
-        extensionCode += " = {postMessage: (e,r) => {external.JavaScriptChannel('";
+        extensionCode += " = {postMessage: (e,r) => {$cef.JavaScriptChannel('";
         extensionCode += channel;
         extensionCode += "',e,r)}};";
     }
@@ -136,7 +136,7 @@ void WebviewHandler::setJavaScriptChannels(int browserId,
 
 ```javascript
 try {
-    Print = {postMessage: (e, r) => { external.JavaScriptChannel('Print', e, r); }};
+    $cef.Print = {postMessage: (e, r) => { $cef.JavaScriptChannel('Print', e, r); }};
 } catch(e) { console.log(e); }
 ```
 
@@ -309,11 +309,11 @@ Dart: controller.evaluateJavascript("1 + 1")
       │
       │ 生成唯一 callbackId（纳秒时间戳）
       │ 包装代码：
-      │   external.EvaluateCallback(callbackId, (function(){ return 1+1; })())
+      │   $cef.EvaluateCallback(callbackId, (function(){ return 1+1; })())
       │ js_callbacks_[callbackId] = callback  ← 保存 Dart 侧 Future 的 completer
       │
       ▼ frame->ExecuteJavaScript(wrappedCode)
-JS 执行 → external.EvaluateCallback(callbackId, 2)
+JS 执行 → $cef.EvaluateCallback(callbackId, 2)
   → [V8 native] CefJSHandler::Execute("EvaluateCallback")
     → CefJSBridge::EvaluateCallback(callbackId, jsValue)
       → SendProcessMessage(PID_BROWSER, kEvaluateCallbackMessage)

--- a/docs/chapter/4-JSBridge详解.md
+++ b/docs/chapter/4-JSBridge详解.md
@@ -1,0 +1,346 @@
+# JSBridge 详解
+
+## 概述
+
+JSBridge 是 `webview_cef` 中最复杂的子系统，实现 JavaScript ↔ Dart 双向通信。有三条通信路径：
+
+| 路径 | JS 入口 | 方向 | 特点 |
+|------|---------|------|------|
+| JavaScriptChannel（无回调） | `Print.postMessage(json)` | JS → Dart | 单向消息 |
+| JavaScriptChannel（有回调） | `Print.postMessage(json, callback)` | JS → Dart → JS | 请求-响应模式 |
+| evaluateJavascript | Dart 侧调用 | Dart → JS → Dart | 执行 JS 并返回值 |
+
+涉及的关键文件：
+
+| 文件 | 角色 |
+|------|------|
+| `common/webview_app.cc` | V8 扩展注册，渲染进程消息处理 |
+| `common/webview_js_handler.h/cc` | `CefJSHandler`（V8 调度）、`CefJSBridge`（回调和跨进程消息） |
+| `common/webview_handler.cc` | `setJavaScriptChannels`、`sendJavaScriptChannelCallBack`、`executeJavaScript` |
+| `common/webview_plugin.cc` | 方法调度，`javascriptChannelMessage` 回调上行的 lambda |
+| `lib/src/webview_manager.dart` | MethodChannel handler，事件分发 |
+| `lib/src/webview.dart` | `setJavaScriptChannels`、`sendJavaScriptChannelCallBack`、`executeJavaScript` |
+| `lib/src/webview_javascript.dart` | `JavascriptChannel`、`JavascriptMessage` 类型 |
+
+---
+
+## 调用链全貌
+
+```
+bridge.html                          setJavaScriptChannels               V8 扩展
+──────────                           ──────────────────                  ────────
+Print.postMessage(msg [, cb]) ──►    Print.postMessage = (e,r) => {      external.JavaScriptChannel
+                                         external.JavaScriptChannel      external.StartRequest
+                                             ('Print', e, r)             external.GetNextReqID
+                                     }                                  external.EvaluateCallback
+```
+
+```
+外部 (JS)                           V8 原生函数                          C++ 渲染进程
+───────                             ────────────                         ────────────
+external.StartRequest(...)    →     native function StartRequest()  →    CefJSHandler::Execute("StartRequest")
+                                                                         CefJSBridge::StartRequest()
+                                                                           → frame->SendProcessMessage(PID_BROWSER)
+```
+
+```
+C++ 浏览器进程                      Dart
+──────────────                      ────
+WebviewHandler::OnProcessMessageReceived
+  → onJavaScriptChannelMessage(...)
+    → WebviewPlugin lambda
+      → m_invokeFunc(...)                                                  → MethodChannel
+                                                                           → WebviewManager.methodCallhandler
+                                                                           → JavascriptChannel.onMessageReceived
+```
+
+---
+
+## 第 1 步：V8 扩展注册
+
+**位置**：`WebviewApp::OnWebKitInitialized()` (`common/webview_app.cc`)
+
+CEF 在每个渲染进程启动时调用此方法一次。它通过 `CefRegisterExtension` 将 JS 代码注入到每个页面的 V8 上下文中，创建 `external` 和 `clientSdk` 两个全局命名空间。
+
+注入的 JS 核心结构：
+
+```javascript
+var external = {};
+var clientSdk = {};
+
+// ── external.JavaScriptChannel(n, e, r) ──
+// n = 通道名（如 "Print"）
+// e = 消息体（会被 JSON.stringify 序列化）
+// r = 可选回调 function(error, result)
+external.JavaScriptChannel = (n, e, r) => {
+    var a;
+    // 如果传了回调，生成唯一函数名存入 window[a]，等待原生侧回调
+    null == r
+        ? a = ''
+        : (a = '_' + new Date + (1e3 + Math.floor(8999 * Math.random())),
+           window[a] = function(n, e) {
+               return function() {
+                   try { e && e.call && e.call(null, arguments[1]); }
+                   finally { delete window[n]; }  // 自清理
+               }
+           }(a, r));
+    // 发送请求：reqID 取负数，以便与 jsCmd 的正数 ID 区分
+    external.StartRequest(external.GetNextReqID(), n, a, JSON.stringify(e || {}), '');
+};
+
+// ── external.StartRequest ── V8 原生函数 → CefJSHandler::Execute("StartRequest")
+external.StartRequest = (nReqID, strCmd, strCallBack, strArgs, strLog) => {
+    native function StartRequest();
+    StartRequest(nReqID, strCmd, strCallBack, strArgs, strLog);
+};
+
+// ── external.GetNextReqID ── 原子递增的请求 ID
+external.GetNextReqID = () => {
+    native function GetNextReqID();
+    return GetNextReqID();
+};
+
+// ── external.EvaluateCallback ── evaluateJavascript 的回调出口
+external.EvaluateCallback = (nReqID, result) => {
+    native function EvaluateCallback();
+    EvaluateCallback(nReqID, result);
+};
+```
+
+**C++ 侧**：`CefRegisterExtension("v8/extern", extensionCode, handler)` 将 `CefJSHandler` 绑定为 V8 原生函数的处理器。JS 中声明的 `native function` 会自动路由到 `CefJSHandler::Execute()`。
+
+---
+
+## 第 2 步：setJavaScriptChannels — 创建通道入口
+
+**位置**：`WebviewHandler::setJavaScriptChannels()` (`common/webview_handler.cc`)
+
+当 Dart 调用 `controller.setJavaScriptChannels({JavascriptChannel(name: 'Print')})` 时，C++ 端生成 JS 代码并执行：
+
+```cpp
+void WebviewHandler::setJavaScriptChannels(int browserId,
+    const std::vector<std::string> channels) {
+    std::string extensionCode = "try{";
+    for (auto& channel : channels) {
+        extensionCode += channel;
+        extensionCode += " = {postMessage: (e,r) => {external.JavaScriptChannel('";
+        extensionCode += channel;
+        extensionCode += "',e,r)}};";
+    }
+    extensionCode += "}catch(e){console.log(e);}";
+    executeJavaScript(browserId, extensionCode);
+}
+```
+
+对于通道 `"Print"`，执行结果：
+
+```javascript
+try {
+    Print = {postMessage: (e, r) => { external.JavaScriptChannel('Print', e, r); }};
+} catch(e) { console.log(e); }
+```
+
+---
+
+## 第 3 步：JS → C++ 跨进程消息
+
+**位置**：`CefJSHandler::Execute("StartRequest")` → `CefJSBridge::StartRequest()` (`common/webview_js_handler.cc`)
+
+### CefJSHandler::Execute — 原生函数调度器
+
+```cpp
+bool CefJSHandler::Execute(const CefString& name, ..., arguments, ...) {
+    if (name == "StartRequest") {
+        int reqId = (int)arguments[0]->GetIntValue();             // 来自 GetNextReqID
+        CefString strCmd = arguments[1]->GetStringValue();        // 通道名 "Print"
+        CefString strCallback = arguments[2]->GetStringValue();   // 回调函数名（或空串）
+        CefString strArgs = arguments[3]->GetStringValue();       // JSON payload
+        js_bridge_->StartRequest(reqId, strCmd, strCallback, strArgs);
+    }
+    // ... GetNextReqID, EvaluateCallback, jsCmd 等
+}
+```
+
+### CefJSBridge::StartRequest — 真正发送消息
+
+```cpp
+bool CefJSBridge::StartRequest(int reqId, const CefString& strCmd,
+                               const CefString& strCallback, const CefString& strArgs) {
+    if (reqId > 0) { reqId *= -1; }  // 取反为负数，区分 jsCmd 的正数 ID
+
+    auto it = startRequest_callback_.find(reqId);
+    if (it == startRequest_callback_.cend()) {
+        CefRefPtr<CefV8Context> context = CefV8Context::GetCurrentContext();
+        CefRefPtr<CefFrame> frame = context->GetFrame();
+        if (frame) {
+            // 构造跨进程消息
+            CefRefPtr<CefProcessMessage> message =
+                CefProcessMessage::Create(kJSCallCppFunctionMessage);
+            message->GetArgumentList()->SetString(0, strCmd);     // 通道名
+            message->GetArgumentList()->SetString(1, strArgs);    // JSON payload
+            message->GetArgumentList()->SetInt(2, reqId);         // 负数 reqId
+
+            // 保存回调信息（用于后续回复）
+            startRequest_callback_.emplace(reqId,
+                std::make_pair(frame, strCallback));
+
+            // ★ 发送跨进程消息：渲染进程 → 浏览器进程
+            frame->SendProcessMessage(PID_BROWSER, message);
+            return true;
+        }
+    }
+    return false;
+}
+```
+
+**设计要点**：`reqId` 被取反为负数，以便在 `ExecuteJSCallbackFunc` 中区分：
+- `callbackId < 0` → JavaScriptChannel 路径（通过 `window[name]` 字符串执行回调）
+- `callbackId > 0` → jsCmd 路径（直接调用保存的 V8 函数引用）
+
+---
+
+## 第 4 步：浏览器进程接收 → Dart
+
+**位置**：`WebviewHandler::OnProcessMessageReceived()` → `WebviewPlugin` lambda → Dart
+
+```cpp
+void WebviewHandler::OnProcessMessageReceived(..., message) {
+    if (message_name == kJSCallCppFunctionMessage) {
+        CefString fun_name = message->GetArgumentList()->GetString(0);  // "Print"
+        CefString param = message->GetArgumentList()->GetString(1);     // JSON
+        int js_callback_id = message->GetArgumentList()->GetInt(2);     // 负数 reqId
+
+        onJavaScriptChannelMessage(fun_name, param,
+            to_string(js_callback_id),
+            browser->GetIdentifier(),
+            frame->GetIdentifier().ToString());
+    }
+}
+```
+
+`onJavaScriptChannelMessage` 在 `WebviewPlugin::initCallback()` 中绑定为一个 lambda，该 lambda 构建 `WValue` map（包含 `channel`、`message`、`callbackId`、`browserId`、`frameId`），然后调用 `m_invokeFunc` 将事件发送到 Dart 侧。
+
+**Dart 侧接收**（`webview_manager.dart` → `webview.dart`）：
+
+```dart
+// WebviewManager.methodCallhandler
+case 'javascriptChannelMessage':
+    _webViews[browserId]?.onJavascriptChannelMessage?.call(
+        call.arguments['channel'],    // "Print"
+        call.arguments['message'],    // JSON payload
+        call.arguments['callbackId'], // 负数 reqId 的字符串形式
+        call.arguments['frameId']);
+
+// WebViewController.onJavascriptChannelMessage
+get onJavascriptChannelMessage => (channelName, message, callbackId, frameId) {
+    if (_javascriptChannels.containsKey(channelName)) {
+        _javascriptChannels[channelName]!.onMessageReceived(
+            JavascriptMessage(message, callbackId, frameId));
+    }
+};
+```
+
+---
+
+## 第 5 步：Dart 回复 → JS 回调
+
+如果 JS 侧传了回调参数，Dart 可以回复：
+
+```dart
+controller.sendJavaScriptChannelCallBack(false, result, message.callbackId, message.frameId);
+```
+
+**C++ 浏览器进程**：`WebviewHandler::sendJavaScriptChannelCallBack` 将回复打包为 `kExecuteJsCallbackMessage` 跨进程消息，发送回渲染进程：
+
+```cpp
+CefRefPtr<CefProcessMessage> message =
+    CefProcessMessage::Create(kExecuteJsCallbackMessage);
+args->SetInt(0, atoi(callbackId.c_str()));  // 负数 reqId
+args->SetBool(1, error);                     // false = 成功
+args->SetString(2, result);                  // 返回值
+frame->SendProcessMessage(PID_RENDERER, message);
+```
+
+**C++ 渲染进程**：`WebviewApp::OnProcessMessageReceived` 接收消息，调用 `CefJSBridge::ExecuteJSCallbackFunc`：
+
+```cpp
+bool CefJSBridge::ExecuteJSCallbackFunc(int callbackId, bool error,
+                                        const CefString& result) {
+    if (callbackId < 0) {
+        // ── JavaScriptChannel 路径 ──
+        auto it = startRequest_callback_.find(callbackId);
+        auto frame = it->second.first;
+        CefString callback = it->second.second;  // 临时函数名
+
+        // 通过 ExecuteJavaScript 调用 window[临时函数名](reqId, result)
+        std::ostringstream strStream;
+        strStream << "window['" << callback.ToString() << "']("
+                  << callbackId * -1 << ", " << result.ToString() << ");";
+        frame->ExecuteJavaScript(strStream.str(), frame->GetURL(), 0);
+        startRequest_callback_.erase(callbackId);
+    } else {
+        // ── jsCmd 路径 ──
+        auto it = render_callback_.find(callbackId);
+        auto context = it->second.first;
+        auto callback = it->second.second.first;
+        context->Enter();
+        CefV8ValueList arguments;
+        arguments.push_back(CefV8Value::CreateBool(error));
+        arguments.push_back(CefV8Value::CreateString(result));
+        callback->ExecuteFunction(nullptr, arguments);  // 直接调用 V8 函数
+        context->Exit();
+        render_callback_.erase(callbackId);
+    }
+}
+```
+
+JS 侧的闭包收到结果，调用用户的原始回调，然后 `delete window[name]` 自清理。
+
+---
+
+## evaluateJavascript 路径（Dart → JS → Dart）
+
+与 JavaScriptChannel 不同，这条路径是 Dart 主动执行 JS 并获取返回值。
+
+```
+Dart: controller.evaluateJavascript("1 + 1")
+  → MethodChannel "evaluateJavascript"
+    → WebviewPlugin → Handler::executeJavaScript(code, callback)
+      │
+      │ 生成唯一 callbackId（纳秒时间戳）
+      │ 包装代码：
+      │   external.EvaluateCallback(callbackId, (function(){ return 1+1; })())
+      │ js_callbacks_[callbackId] = callback  ← 保存 Dart 侧 Future 的 completer
+      │
+      ▼ frame->ExecuteJavaScript(wrappedCode)
+JS 执行 → external.EvaluateCallback(callbackId, 2)
+  → [V8 native] CefJSHandler::Execute("EvaluateCallback")
+    → CefJSBridge::EvaluateCallback(callbackId, jsValue)
+      → SendProcessMessage(PID_BROWSER, kEvaluateCallbackMessage)
+        → WebviewHandler::OnProcessMessageReceived
+          → js_callbacks_.find(callbackId) → it->second(param)
+            → result(1, retValue) → Dart Future 完成
+```
+
+---
+
+## CefJSBridge 回调映射
+
+```cpp
+class CefJSBridge {
+    // startRequest_callback_ — JavaScriptChannel 路径
+    // key: 负数 reqId
+    // value: (Frame, callbackName字符串)
+    typedef std::map<int, std::pair<CefRefPtr<CefFrame>, CefString>>
+        StartRequestCallbackMap;
+
+    // render_callback_ — jsCmd 路径
+    // key: 正数 js_callback_id
+    // value: (V8Context, (V8Function callback, V8Value rawdata))
+    typedef std::map<int, std::pair<CefRefPtr<CefV8Context>,
+        std::pair<CefRefPtr<CefV8Value>, CefRefPtr<CefV8Value>>>>
+        RenderCallbackMap;
+};
+```
+
+**内存管理**：当页面导航离开或 V8 上下文被释放时，`RemoveCallbackFuncWithFrame(frame)` 清除该 frame 的所有回调条目，防止悬空引用。

--- a/docs/chapter/4-JSBridge详解.md
+++ b/docs/chapter/4-JSBridge详解.md
@@ -68,77 +68,92 @@ CEF 在每个渲染进程启动时调用此方法一次。它通过 `CefRegister
 var $cef = {};
 var clientSdk = {};
 
-// ── $cef.JavaScriptChannel(n, e, r) ──
-// n = 通道名（如 "Print"）
-// e = 消息体（会被 JSON.stringify 序列化）
-// r = 可选回调 function(error, result)
-$cef.JavaScriptChannel = (n, e, r) => {
-    var a;
-    // 如果传了回调，生成唯一函数名存入 window[a]，等待原生侧回调
-    null == r
-        ? a = ''
-        : (a = '_' + new Date + (1e3 + Math.floor(8999 * Math.random())),
-           window[a] = function(n, e) {
-               return function() {
-                   try { e && e.call && e.call(null, arguments[1]); }
-                   finally { delete window[n]; }  // 自清理
-               }
-           }(a, r));
-    // 发送请求：reqID 取负数，以便与 jsCmd 的正数 ID 区分
-    $cef.StartRequest($cef.GetNextReqID(), n, a, JSON.stringify(e || {}), '');
-};
+(() => {
+    // ── $cef.JavaScriptChannel(n, e, r) ──
+    // n = 通道名（如 "Print"）
+    // e = 消息体（会被 JSON.stringify 序列化）
+    // r = 可选回调 function(error, result)
+    $cef.JavaScriptChannel = (n, e, r) => {
+        var a;
+        // 如果传了回调，生成唯一函数名存入 window[a]，等待原生侧回调
+        null == r
+            ? a = ''
+            : (a = '_' + new Date + (1e3 + Math.floor(8999 * Math.random())),
+               window[a] = function(n, e) {
+                   return function() {
+                       try { e && e.call && e.call(null, arguments[1]); }
+                       finally { delete window[n]; }  // 自清理
+                   }
+               }(a, r));
+        // 发送请求：reqID 取负数，以便与 jsCmd 的正数 ID 区分
+        $cef.StartRequest($cef.GetNextReqID(), n, a, JSON.stringify(e || {}), '');
+    };
 
-// ── $cef.StartRequest ── V8 原生函数 → CefJSHandler::Execute("StartRequest")
-$cef.StartRequest = (nReqID, strCmd, strCallBack, strArgs, strLog) => {
-    native function StartRequest();
-    StartRequest(nReqID, strCmd, strCallBack, strArgs, strLog);
-};
+    // ── $cef.StartRequest ── V8 原生函数 → CefJSHandler::Execute("StartRequest")
+    $cef.StartRequest = (nReqID, strCmd, strCallBack, strArgs, strLog) => {
+        native function StartRequest();
+        StartRequest(nReqID, strCmd, strCallBack, strArgs, strLog);
+    };
 
-// ── $cef.GetNextReqID ── 原子递增的请求 ID
-$cef.GetNextReqID = () => {
-    native function GetNextReqID();
-    return GetNextReqID();
-};
+    // ── $cef.GetNextReqID ── 原子递增的请求 ID
+    $cef.GetNextReqID = () => {
+        native function GetNextReqID();
+        return GetNextReqID();
+    };
 
-// ── $cef.EvaluateCallback ── evaluateJavascript 的回调出口
-$cef.EvaluateCallback = (nReqID, result) => {
-    native function EvaluateCallback();
-    EvaluateCallback(nReqID, result);
-};
+    // ── $cef.EvaluateCallback ── evaluateJavascript 的回调出口
+    $cef.EvaluateCallback = (nReqID, result) => {
+        native function EvaluateCallback();
+        EvaluateCallback(nReqID, result);
+    };
+
+    // ── Proxy 包装 ──
+    // 任何对 $cef 的未知属性访问（如 $cef.Print、$cef.MyChannel）
+    // 自动返回 {postMessage} 对象，无需 executeJavaScript 注入。
+    // 通道从页面加载第一刻即可用，并跨所有导航持久存在。
+    $cef = new Proxy($cef, {
+        get: function(target, prop, receiver) {
+            if (prop in target) {
+                return Reflect.get(target, prop, receiver);
+            }
+            if (typeof prop === 'string') {
+                return {
+                    postMessage: function(e, r) {
+                        $cef.JavaScriptChannel(prop, e, r);
+                    }
+                };
+            }
+            return Reflect.get(target, prop, receiver);
+        }
+    });
+})();
 ```
 
 **C++ 侧**：`CefRegisterExtension("v8/extern", extensionCode, handler)` 将 `CefJSHandler` 绑定为 V8 原生函数的处理器。JS 中声明的 `native function` 会自动路由到 `CefJSHandler::Execute()`。
 
 ---
 
-## 第 2 步：setJavaScriptChannels — 创建通道入口
+## 第 2 步：setJavaScriptChannels — 通道注册
 
 **位置**：`WebviewHandler::setJavaScriptChannels()` (`common/webview_handler.cc`)
 
-当 Dart 调用 `controller.setJavaScriptChannels({JavascriptChannel(name: 'Print')})` 时，C++ 端生成 JS 代码并执行：
+当 Dart 调用 `controller.setJavaScriptChannels({JavascriptChannel(name: 'Print')})` 时，C++ 端**不再需要生成或注入任何 JS 代码**。V8 扩展中的 Proxy 会自动为 `$cef.Print` 创建 `{postMessage}` 对象。
 
 ```cpp
 void WebviewHandler::setJavaScriptChannels(int browserId,
     const std::vector<std::string> channels) {
-    std::string extensionCode = "try{";
-    for (auto& channel : channels) {
-        extensionCode += channel;
-        extensionCode += " = {postMessage: (e,r) => {$cef.JavaScriptChannel('";
-        extensionCode += channel;
-        extensionCode += "',e,r)}};";
-    }
-    extensionCode += "}catch(e){console.log(e);}";
-    executeJavaScript(browserId, extensionCode);
+    // No-op: V8 扩展中的 $cef Proxy 自动处理所有通道名。
+    // 无需 executeJavaScript 注入，无需 OnLoadEnd 重新注入。
+    (void)browserId;
+    (void)channels;
 }
 ```
 
-对于通道 `"Print"`，执行结果：
+**为什么是空操作？** V8 扩展在 `OnWebKitInitialized` 中注册了 `$cef` 的 Proxy 包装器。当页面 JS 访问 `$cef.Print` 时，Proxy 的 `get` 陷阱自动返回一个 `{postMessage}` 对象，该对象内部调用 `$cef.JavaScriptChannel('Print', e, r)`。因此：
 
-```javascript
-try {
-    $cef.Print = {postMessage: (e, r) => { $cef.JavaScriptChannel('Print', e, r); }};
-} catch(e) { console.log(e); }
-```
+- 通道从页面加载的第一刻起就可调用
+- 通道在页面导航后仍然存活（V8 扩展会被重新注入到每个 V8 上下文中）
+- Dart 侧的 `_javascriptChannels` map 仍然用于将收到的消息分发到正确的回调函数
 
 ---
 

--- a/docs/chapter/5-渲染管线.md
+++ b/docs/chapter/5-渲染管线.md
@@ -1,0 +1,156 @@
+# 渲染管线
+
+## 两种渲染路径
+
+CEF 通过两种方式将网页像素输出到 Flutter：
+
+| 路径 | CEF 回调 | 数据格式 | 性能 |
+|------|----------|----------|------|
+| **GPU 零拷贝** | `OnAcceleratedPaint` | IOSurface (macOS) / D3D11 共享纹理 (Windows) | 高 — 数据不经过 CPU |
+| **软件回退** | `OnPaint` | CPU BGRA 像素缓冲区 | 低 — 需要 CPU 拷贝和像素格式转换 |
+
+GPU 路径通过 `WEBVIEW_CEF_GPU_TEXTURE` 编译时标志控制。启用时：
+
+- CEF 的 `shared_texture_enabled` 和 `external_begin_frame_enabled` 设为 `true`
+- 帧由外部时钟（vblank）驱动，而非 CEF 内部 60fps 定时器
+- macOS 使用 Metal，Windows 使用 D3D11
+
+---
+
+## 跨平台渲染流程
+
+```
+CEF 渲染帧
+  │
+  ├── 软件路径: OnPaint(buffer, w, h)
+  │   → WebviewHandler::OnPaint()
+  │     → onPaintCallback(browserId, buffer, w, h)
+  │       → WebviewTexture::onFrame(buffer, w, h)
+  │         → BGRA→RGBA 转换 (非 macOS)
+  │         → 平台 Texture 注册器标记可用
+  │
+  └── GPU 路径: OnAcceleratedPaint(shared_texture_handle)
+      → WebviewHandler::OnAcceleratedPaint()
+        → onAcceleratedPaintCallback(browserId, handle, w, h, format)
+          → WebviewTexture::onAcceleratedFrame(handle, w, h, format)
+            → Metal/D3D11 GPU Blit
+            → 平台 Texture 注册器标记可用
+```
+
+---
+
+## macOS
+
+### 软件路径
+
+`WebviewCefTexture.onFrame:width:height:` 方法：
+
+1. 通过 `CVPixelBufferCreate` 创建 `CVPixelBuffer`
+2. 按行 `memcpy` 将 CEF 的 BGRA 数据拷贝到 pixel buffer（处理 16 字节对齐）
+3. Flutter 引擎通过 `copyPixelBuffer` 获取帧
+
+### GPU 路径（Metal 零拷贝）
+
+`WebviewCefTexture.onAcceleratedFrame:` 方法：
+
+1. CEF 交付一个 `IOSurfaceRef`（CEF 在回调返回后会回收它）
+2. 从 `CVPixelBufferPool` 取出一个由 IOSurface 支持的目标 `CVPixelBuffer`
+3. 使用 Metal 创建源纹理（封装 CEF IOSurface）和目标纹理
+4. 通过 `MTLBlitCommandEncoder` 提交 GPU Blit 拷贝
+5. `[cmd waitUntilCompleted]` 确保拷贝完成后再让 CEF 回收源表面
+
+**为什么不能直接把 CEF 的 IOSurface 给 Flutter？** 因为 CEF 在 `OnAcceleratedPaint` 返回后立即回收纹理。必须通过一次 GPU 拷贝将内容转移到自己控制的 buffer 中。
+
+### 帧时钟
+
+```
+CVDisplayLink (vblank 回调)
+  → doMessageLoopWork()       // 处理 CEF 消息
+    → beginFrameAllPlugins()
+      → tickBeginFrame() → sendExternalBeginFrame()
+```
+
+如果 `CVDisplayLink` 创建失败（如无头模式），则回退到 16ms `NSTimer`。
+
+---
+
+## Windows
+
+### 软件路径
+
+`WebviewTextureRenderer::onFrame()`：
+1. 分配/重新分配 `FlutterDesktopPixelBuffer`
+2. 调用 `SwapBufferFromBgraToRgba()` 将 BGRA 转为 RGBA
+3. 调用 `FlutterDesktopTextureRegistrarMarkExternalTextureFrameAvailable`
+
+### GPU 路径（D3D11 共享纹理）
+
+`WebviewGpuTextureRenderer` 类：
+
+1. 创建硬件 D3D11 设备（失败则回退到 WARP 软件渲染器）
+2. CEF 的 `OnAcceleratedPaint` 交付共享纹理 `HANDLE`
+3. `device_->OpenSharedResource1(handle)` 打开 CEF 纹理
+4. `EnsureBridgeTexture()` 创建一个与 Flutter 共享的桥接纹理（`D3D11_RESOURCE_MISC_SHARED`）
+5. `context_->CopyResource(bridge_tex, cef_tex)` + `Flush()`
+6. Flutter 引擎通过 `ObtainDescriptor()` 获取 DXGI 共享句柄
+
+### 帧时钟
+
+```
+VsyncThreadProc (独立线程)
+  → IDXGIOutput::WaitForVBlank()
+    → tickBeginFrame() → sendExternalBeginFrame()
+```
+
+如果 DXGI VBlank 不可用，回退到 `QueryRefreshIntervalMs()`。
+
+---
+
+## Linux
+
+仅支持软件路径。
+
+`WebviewTextureRenderer::onFrame()`：
+1. `SwapBufferFromBgraToRgba()` 转换像素格式
+2. 纹理是 `FlPixelBufferTexture` 的 GObject 子类
+3. `fl_texture_registrar_mark_texture_frame_available` 通知 Flutter
+
+---
+
+## eLinux
+
+仅支持软件路径，与 Linux 类似，但使用 Flutter 的通用 C++ 客户端包装器 API。
+
+`WebviewTextureRenderer::onFrame()`：
+1. `SwapBufferFromBgraToRgba()` 转换
+2. 通过 `flutter::PixelBufferTexture` lambda 交付像素
+3. `registrar_->MarkTextureFrameAvailable()`
+
+---
+
+## SwapBufferFromBgraToRgba
+
+软件路径通用的像素格式转换工具（`common/webview_plugin.cc`）：
+
+```
+BGRA 格式（CEF 输出）          RGBA 格式（Flutter 需要）
+┌───┬───┬───┬───┐              ┌───┬───┬───┬───┐
+│ B │ G │ R │ A │     →        │ R │ G │ B │ A │
+└───┴───┴───┴───┘              └───┴───┴───┴───┘
+
+交换 Blue 和 Red 字节，保留 Green 和 Alpha
+```
+
+macOS 不需要此转换，因为 macOS 的 `CVPixelBuffer` 原生支持 BGRA 格式。
+
+---
+
+## 外部 BeginFrame 机制
+
+当 `external_begin_frame_enabled = true` 时：
+
+- CEF **不会**内部驱动帧生成（不按固定 60fps 定时器渲染）
+- 平台层通过 `sendExternalBeginFrame()` 按需请求帧
+- 帧率跟随显示器刷新率（如 120Hz ProMotion）
+
+**焦点重断言（Focus Re-assert）**：使用 `external_begin_frame` 时，CEF 浏览器创建后可能无法立即接收 `SetFocus(true)` 调用。`OnAcceleratedPaint` 中有一个补救措施：在第一帧到达时自动重新断言请求的焦点状态。

--- a/docs/chapter/6-平台输入处理.md
+++ b/docs/chapter/6-平台输入处理.md
@@ -80,6 +80,34 @@ NSEvent keyDown
 | Command | `EVENTFLAG_COMMAND_DOWN` |
 | Numpad | `EVENTFLAG_IS_KEY_PAD` |
 
+### OSR 模式快捷键处理
+
+CEF 离屏渲染（Off-Screen Rendering）绕过 AppKit 的 `interpretKeyEvents:`，导致带有 Cmd 修饰键的编辑快捷键（如 ⌘← 跳到行首、⌘Z 撤销）无法被 AppKit 翻译为编辑指令。`WebviewPlugin::handleMacOSOSRShortcut()` 在 C++ 层拦截这些组合键，通过 JavaScript 直接执行等效的编辑操作。
+
+**拦截时机**：`sendKeyEvent()` 中，在将事件转发给 CEF 之前调用 `handleMacOSOSRShortcut()`。若方法返回 `true`，事件被消费，不再转发。
+
+**支持的热键**：
+
+| 组合键 | native_key_code | 编辑操作 |
+|--------|-----------------|----------|
+| ⌘⌫ | 51 | 删除到行首（`deleteToBeginningOfLine`） |
+| ⌘← | 123 | 光标移到行首 |
+| ⌘⇧← | 123 | 选中到行首 |
+| ⌘→ | 124 | 光标移到行尾 |
+| ⌘⇧→ | 124 | 选中到行尾 |
+| ⌘↑ | 126 | 光标移到文档开头 |
+| ⌘⇧↑ | 126 | 选中到文档开头 |
+| ⌘↓ | 125 | 光标移到文档末尾 |
+| ⌘⇧↓ | 125 | 选中到文档末尾 |
+| ⌘Z | 6 | 撤销（`execCommand('undo')`） |
+| ⌘⇧Z | 6 | 重做（`execCommand('redo')`） |
+
+**实现细节**：
+- 仅对 `INPUT` 和 `TEXTAREA` 元素执行（撤销/重做除外，因其对 `contenteditable` 元素也生效）
+- 行首/行尾移动通过 `lastIndexOf('\n')` 和 `indexOf('\n')` 计算光标位置
+- 带 Shift 的选区扩展：←/↑ 方向使用 `Math.max()` 取右侧锚点，→/↓ 方向使用 `Math.min()` 取左侧锚点
+- 所有逻辑通过 `#ifdef OS_MAC` 守卫，不影响其他平台
+
 ---
 
 ## Windows 键盘输入

--- a/docs/chapter/6-平台输入处理.md
+++ b/docs/chapter/6-平台输入处理.md
@@ -82,31 +82,60 @@ NSEvent keyDown
 
 ### OSR 模式快捷键处理
 
-CEF 离屏渲染（Off-Screen Rendering）绕过 AppKit 的 `interpretKeyEvents:`，导致带有 Cmd 修饰键的编辑快捷键（如 ⌘← 跳到行首、⌘Z 撤销）无法被 AppKit 翻译为编辑指令。`WebviewPlugin::handleMacOSOSRShortcut()` 在 C++ 层拦截这些组合键，通过 JavaScript 直接执行等效的编辑操作。
+CEF 离屏渲染（Off-Screen Rendering）绕过 AppKit 的 `interpretKeyEvents:`，导致带有 Cmd 修饰键的编辑快捷键无法被 AppKit 翻译为编辑指令。分两层处理：
 
-**拦截时机**：`sendKeyEvent()` 中，在将事件转发给 CEF 之前调用 `handleMacOSOSRShortcut()`。若方法返回 `true`，事件被消费，不再转发。
+**C++ 层**（`handleMacOSOSRShortcut`）：在 `sendKeyEvent()` 中将事件转发给 CEF 之前拦截。大部分编辑快捷键通过 JavaScript `execCommand()` 或 `setSelectionRange()` 模拟。若方法返回 `true`，事件被消费。
+
+**Obj-C 层**（`CefWrapper.mm`）：Cmd+V（粘贴）单独在平台层拦截，因为粘贴需要读取系统剪贴板（`NSPasteboard`），只能通过 macOS 原生 API 获取。拦截后调用 `WebviewPlugin::pasteText()` 将文本注入焦点元素。
 
 **支持的热键**：
 
-| 组合键 | native_key_code | 编辑操作 |
-|--------|-----------------|----------|
-| ⌘⌫ | 51 | 删除到行首（`deleteToBeginningOfLine`） |
-| ⌘← | 123 | 光标移到行首 |
-| ⌘⇧← | 123 | 选中到行首 |
-| ⌘→ | 124 | 光标移到行尾 |
-| ⌘⇧→ | 124 | 选中到行尾 |
-| ⌘↑ | 126 | 光标移到文档开头 |
-| ⌘⇧↑ | 126 | 选中到文档开头 |
-| ⌘↓ | 125 | 光标移到文档末尾 |
-| ⌘⇧↓ | 125 | 选中到文档末尾 |
-| ⌘Z | 6 | 撤销（`execCommand('undo')`） |
-| ⌘⇧Z | 6 | 重做（`execCommand('redo')`） |
+| 组合键 | key code | 拦截层 | 编辑操作 |
+|--------|----------|--------|----------|
+| ⌘C | 8 | C++ 层 `handleMacOSOSRShortcut` | 拷贝选中文本（`execCommand('copy')`） |
+| ⌘V | 9 | Obj-C 层 `CefWrapper.mm` | 粘贴系统剪贴板内容（`NSPasteboard` → `pasteText()`） |
+| ⌘⌫ | 51 | C++ 层 `handleMacOSOSRShortcut` | 删除到行首 |
+| ⌘← | 123 | C++ 层 | 光标移到行首 |
+| ⌘⇧← | 123 | C++ 层 | 选中到行首 |
+| ⌘→ | 124 | C++ 层 | 光标移到行尾 |
+| ⌘⇧→ | 124 | C++ 层 | 选中到行尾 |
+| ⌘↑ | 126 | C++ 层 | 光标移到文档开头 |
+| ⌘⇧↑ | 126 | C++ 层 | 选中到文档开头 |
+| ⌘↓ | 125 | C++ 层 | 光标移到文档末尾 |
+| ⌘⇧↓ | 125 | C++ 层 | 选中到文档末尾 |
+| ⌘Z | 6 | C++ 层 | 撤销 |
+| ⌘⇧Z | 6 | C++ 层 | 重做 |
+
+**粘贴流程详解**：
+
+```
+Cmd+V (NSEventTypeKeyDown, keyCode=9, Command)
+  → CefWrapper.mm: processKeyboardEvent:
+    → [[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString]
+    → plugin->pasteText(text)
+      → 转义特殊字符（\"、\n、\r、\t、\\）
+      → 构建 JS：
+        · INPUT / TEXTAREA：splice 拼接文本 + dispatchEvent('input')
+        · contenteditable：execCommand('insertText')
+      → executeJavaScript(bId, js)
+```
+
+**为什么只有 macOS 需要特殊处理？**
+
+| 平台 | 快捷键体系 | 剪贴板 / 编辑指令如何实现 | OSR 是否需要特殊处理 |
+|------|-----------|--------------------------|---------------------|
+| **macOS** | Cmd+ 组合键 | AppKit `interpretKeyEvents:` 将按键翻译为 `copy:` / `paste:` / `moveToBeginningOfLine:` 等 selector | **需要** — OSR 绕过了 AppKit 管线，selector 永远不会触发 |
+| **Windows** | Ctrl+ 组合键 | CEF 内核直接调用 Win32 剪贴板 API（`OpenClipboard` / `GetClipboardData`）和编辑逻辑 | **不需要** — CEF 原生处理，不依赖中间层 |
+| **Linux** | Ctrl+ 组合键 | CEF 内核直接调用 GTK / X11 剪贴板 API 和编辑逻辑 | **不需要** — 同上 |
+| **eLinux** | 无原生支持 | Dart 侧 `RawKeyboard` 发送 `KeyEvent` → CEF 内核处理 | **不需要** — 同上 |
+
+简而言之：macOS 是唯一将快捷键翻译交给 **应用层中间件（AppKit）** 的平台。CEF 在窗口模式下依赖 AppKit 完成这一翻译，但在 OSR 模式下 AppKit 被短路，必须手动实现。Windows / Linux 的 CEF 内核直接访问系统 API，不受渲染模式影响。
 
 **实现细节**：
-- 仅对 `INPUT` 和 `TEXTAREA` 元素执行（撤销/重做除外，因其对 `contenteditable` 元素也生效）
+- 除拷贝、粘贴、撤销/重做外，仅对 `INPUT` 和 `TEXTAREA` 元素执行
 - 行首/行尾移动通过 `lastIndexOf('\n')` 和 `indexOf('\n')` 计算光标位置
 - 带 Shift 的选区扩展：←/↑ 方向使用 `Math.max()` 取右侧锚点，→/↓ 方向使用 `Math.min()` 取左侧锚点
-- 所有逻辑通过 `#ifdef OS_MAC` 守卫，不影响其他平台
+- 所有 C++ 层逻辑通过 `#ifdef OS_MAC` 守卫，不影响其他平台
 
 ---
 

--- a/docs/chapter/6-平台输入处理.md
+++ b/docs/chapter/6-平台输入处理.md
@@ -1,0 +1,171 @@
+# 平台输入处理
+
+## 鼠标 / 指针输入（跨平台）
+
+所有平台的鼠标事件统一由 Dart 侧 `WebViewState._buildInner()` 中的 `Listener` widget 采集，通过 MethodChannel 发送到 C++ 层。
+
+```
+Flutter Listener 事件 → MethodChannel → WebviewPlugin → WebviewHandler → CEF API
+─────────────────────     ────────────     ────────────     ──────────────    ────────
+onPointerHover         →  cursorMove    →  cursorMove    →  cursorMove     → SendMouseMoveEvent
+onPointerDown          →  cursorClickDown → cursorClick  →  cursorClick    → SendMouseClickEvent
+onPointerUp            →  cursorClickUp   → cursorClick  →  cursorClick    → SendMouseClickEvent
+onPointerMove          →  cursorDragging  →  cursorMove   →  cursorMove     → SendMouseMoveEvent
+onPointerSignal        →  setScrollDelta  →  sendScrollEvent → sendScrollEvent → SendMouseWheelEvent
+onPointerPanZoomUpdate →  setScrollDelta  →  sendScrollEvent → sendScrollEvent → SendMouseWheelEvent
+```
+
+### 滚动特殊处理
+
+在 `WebviewHandler::sendScrollEvent()` 中：
+
+- **非 macOS 平台**：`deltaY = -deltaY`（方向取反）
+- **非 macOS 平台**：`deltaX * 10, deltaY * 10`（速度放大 10 倍，因为 Flutter 滚轮速度偏慢）
+
+### 光标类型
+
+CEF 通过 `OnCursorChange` 通知光标类型，映射关系：
+
+| CEF 类型 | Flutter MouseCursor |
+|----------|---------------------|
+| 0 | SystemMouseCursors.basic |
+| 1 | SystemMouseCursors.precise |
+| 2 | SystemMouseCursors.click |
+| 3 | SystemMouseCursors.text |
+| 4 | SystemMouseCursors.wait |
+
+---
+
+## macOS 键盘输入
+
+### 事件拦截
+
+使用 `NSEvent addLocalMonitorForEventsMatchingMask:` 安装全局监视器，拦截 `NSEventMaskKeyDown` 和 `NSEventMaskKeyUp`。
+
+### 路由逻辑
+
+`processKeyboardEvent:` 方法的核心决策：
+
+```
+NSEvent keyDown
+  │
+  ├── 当前有可编辑焦点，且 (正在组合输入 或 isImeRoutableKey)?
+  │     YES → 返回 false，让事件传递给 Flutter/IME 管道
+  │              │
+  │              Flutter DeltaTextInput
+  │                → WebeViewTextInput.updateEditingValueWithDeltas
+  │                  → imeSetComposition / imeCommitText
+  │
+  └── NO → 构建 CefKeyEvent → sendKeyEvent → CEF
+```
+
+### 哪些键路由给 IME？
+
+`isImeRoutableKeyEvent:` 的逻辑：
+
+- 如果修饰键包含 **Cmd** 或 **Ctrl** → 路由给 CEF（快捷键）
+- **导航/控制键白名单**（F1-F12、Tab、Return、Delete、Escape、Home、End、Page Up/Down、方向键）→ 路由给 CEF
+- **产生字符的键**（字母、数字、标点等）→ 路由给操作系统 IME（进入 Flutter DeltaTextInput 管道）
+
+### 修饰键映射
+
+`getModifiersForEvent:` 将 macOS 修饰键标志映射为 CEF 事件标志：
+
+| macOS 修饰键 | CEF 标志 |
+|-------------|----------|
+| CapsLock | `EVENTFLAG_CAPS_LOCK_ON` |
+| Shift | `EVENTFLAG_SHIFT_DOWN` |
+| Control | `EVENTFLAG_CONTROL_DOWN` |
+| Option/Alt | `EVENTFLAG_ALT_DOWN` |
+| Command | `EVENTFLAG_COMMAND_DOWN` |
+| Numpad | `EVENTFLAG_IS_KEY_PAD` |
+
+---
+
+## Windows 键盘输入
+
+### 键盘处理
+
+`handleMessageProc()` 拦截 `WM_KEYDOWN`、`WM_KEYUP`、`WM_CHAR`、`WM_SYSKEYDOWN`、`WM_SYSKEYUP`、`WM_SYSCHAR` 消息，通过 `getCefKeyEvent()` 转换为 `CefKeyEvent` 后发送给 CEF。
+
+### IME 处理（原生管道）
+
+Windows IME 通过 **HWND 子类化** 实现，完全绕过 Flutter 的 TextInput：
+
+```
+原始 Flutter View HWND (WndProc)
+  │
+  └── ImeSubclassProc (通过 SetWindowSubclass 挂载)
+        │
+        ├── WM_IME_SETCONTEXT    → 隐藏系统候选窗口
+        ├── WM_IME_STARTCOMPOSITION → 抑制默认 UI
+        ├── WM_IME_COMPOSITION   → 通过 ImmGetCompositionStringW 读取
+        │     ├── GCS_RESULTSTR  → imeCommitTextNative(text)
+        │     └── GCS_COMPSTR    → imeSetCompositionNative(text, cursor)
+        └── WM_IME_ENDCOMPOSITION → imeFinishCompositionNative()
+```
+
+**与 macOS 的关键区别**：Windows 使用完全独立的原生 IME 管道。`WebeViewTextInput` mixin 在 `Platform.isWindows` 时特意 `return`，不建立 `TextInputConnection`。
+
+### 修饰键检测
+
+`GetCefKeyboardModifiers()` 通过 `GetKeyState` 检测 CapsLock、NumLock、左右 Ctrl/Alt/Shift 以及 AltGr（通过 `VkKeyScanExW` 判断）。
+
+---
+
+## Linux 键盘输入（GTK）
+
+### 入口
+
+`processKeyEventForCEF(GtkWidget*, GdkEventKey*, gpointer)` 由 Flutter 应用的 GTK 信号处理器调用。
+
+### 键码映射
+
+1. `GdkEventToWindowsKeyCode()` — 将 GDK 键值转换为 Windows 虚拟键码
+2. `KeyboardCodeFromXKeysym()` — 映射 ~140 个 X11 键符号
+
+### 特殊处理
+
+| 组合键 | 处理 |
+|--------|------|
+| Ctrl+V | 运行 `xclip` 命令粘贴（修复已知的冻结问题） |
+| Ctrl+A–Ctrl+Z | 映射为控制字符（ASCII 1–26） |
+| Return | `unmodified_character` 设为 `<br>` |
+
+---
+
+## eLinux 键盘输入
+
+eLinux 没有原生键处理能力（`hasNativeKeySupport = false`），完全由 Dart 侧处理。
+
+### 流程
+
+```
+Flutter KeyEvent (RawKeyboard)
+  → WebViewState._onKeyEvent()
+    → _logicalKeyToWindowsKeyCode(key)  // Flutter 逻辑键 → Windows 虚拟键码
+    → 构建修饰键标志（Shift/Ctrl/Alt）
+    → sendKeyEvent(type, keyCode, modifiers, character, unmodifiedCharacter)
+      → MethodChannel → CEF
+```
+
+- `KeyDownEvent` 时发送 `KEYEVENT_RAWKEYDOWN`，有字符时附带 `KEYEVENT_CHAR`
+- `KeyUpEvent` 时发送 `KEYEVENT_KEYUP`
+
+---
+
+## IME 组合范围跟踪
+
+当网页中的可编辑元素获得焦点时，CEF 通过 `OnImeCompositionRangeChanged` 提供光标位置。该信息用于在文本上方精确定位 IME 候选窗口：
+
+```
+CEF → OnImeCompositionRangeChanged
+  → WebviewHandler → onImeCompositionRangeChangedMessage(browserId, x, y, height)
+    → WebviewPlugin lambda → m_invokeFunc
+      → MethodChannel → Dart
+        → WebViewState._onImeCompositionRangeChangedMessage
+          → updateIMEComposionPosition(x, y, height, offset)
+            → TextInput.setEditableSizeAndTransform
+            → TextInput.setComposingRect
+            → TextInput.setCaretRect
+```

--- a/docs/chapter/7-构建与集成.md
+++ b/docs/chapter/7-构建与集成.md
@@ -13,6 +13,112 @@ CEF 标准发行版（包含 `Chromium Embedded Framework.framework`、`libcef_d
 
 ---
 
+## 输入与输出
+
+本节按平台梳理 CEF 从下载到最终打包的三阶段文件流转：
+
+1. **远程拉取** — 从 Spotify CDN 下载的 CEF 官方发行版包含哪些内容
+2. **中间产物** — 构建过程中生成的文件，用完即删或仅编译时使用，不进入 App
+3. **最终打包** — 真正随 App 分发的文件
+
+---
+
+### CEF 官方发行版内容（所有平台通用）
+
+无论哪个平台，从 CDN 下载的 CEF tarball（约 300 MB）都包含以下标准内容：
+
+| 内容 | 说明 |
+|------|------|
+| 运行时二进制 | macOS: `Chromium Embedded Framework.framework/`（dylib + Resources）; Windows: `Release/`（`libcef.dll` 等）; Linux: `Release/`（`libcef.so` 等） |
+| `Resources/` | `.pak` 资源文件 + `icudtl.dat`（国际化数据）+ V8 快照 |
+| `include/` | C API 头文件（约 100 个），供项目 `#include` 使用 |
+| `libcef_dll_wrapper/` | C++ 包装器 **源码**，不是二进制，需本地 cmake 编译为 `.a` / `.lib` |
+| `cmake/` | CEF CMake 辅助模块（`cef_variables.cmake` 等） |
+
+---
+
+### macOS
+
+#### 三阶段文件流转
+
+| 阶段 | 内容 | 来源 | 去向 |
+|------|------|------|------|
+| **远程拉取** | `cef_binary_*_macosarm64.tar.bz2`<br>`cef_binary_*_macosx64.tar.bz2` | Spotify CDN | 解压到临时目录 `_build_arm64/`、`_build_x86_64/` |
+| **中间产物** | 单架构 `libcef_dll_wrapper.a` | cmake 编译 CEF 包装器源码 | lipo 合并后丢弃 |
+| | 单架构 `cef_helper` | clang++ 编译 `common/` + `helper/` 源码 | lipo 合并后丢弃 |
+| | 单架构 framework 内 dylib（5 个 Mach-O） | CEF tarball 解压 | lipo 合并为 Universal 后丢弃 |
+| | `include/` | 从 tarball 复制到 `macos/third/cef/` | 仅编译时使用，不进入 App |
+| | `version.txt` | `download_cef.sh` 写入的缓存戳记 | 幂等校验，不进入 App |
+| **最终打包** | `Chromium Embedded Framework.framework/`（Universal） | 7 个 Mach-O 经 `lipo` 合并 | ✅ `Runner.app/Contents/Frameworks/` |
+| | `libcef_dll_wrapper.a`（Universal） | `lipo -create` 合并双架构 | ✅ 链接进插件二进制（无独立文件） |
+| | `cef_helper`（Universal） | `lipo -create` 合并双架构 | ✅ `embed_cef_helpers.sh` 克隆为 5 个 Helper `.app`，放入 `Contents/Frameworks/` |
+
+> **关键点**：`macos/third/cef/` 中只有 3 个文件参与打包（framework、cef_helper、wrapper）；`include/`、`version.txt` 为纯构建辅助。中间产物（`_build_*`）由 `trap cleanup EXIT` 自动清理。整个 `macos/third/cef/` 被 `.gitignore` 排除。
+
+---
+
+### Windows
+
+#### 三阶段文件流转
+
+| 阶段 | 内容 | 来源 | 去向 |
+|------|------|------|------|
+| **远程拉取** | `cef_binary_*_windows64.tar.bz2` | Spotify CDN | 解压到 `third/cef/` |
+| **中间产物** | `libcef_dll_wrapper.lib` | cmake 编译 CEF 包装器源码 | 链接进 `webview_cef_plugin.dll` |
+| | `include/` + `cmake/` | 从 tarball 解压 | 仅编译时使用 |
+| | `prebuilt.zip` | 临时下载缓存 | 解压后删除 |
+| **最终打包** | `libcef.dll`、`chrome_elf.dll` | CEF tarball → `third/cef/Release/` | ✅ 捆绑到 exe 同目录 |
+| | `libEGL.dll`、`libGLESv2.dll` | CEF tarball | ✅ 捆绑 |
+| | `snapshot_blob.bin`、`v8_context_snapshot.bin` | CEF tarball | ✅ 捆绑 |
+| | `*.pak`（`cef.pak`、`cef_100_percent.pak` 等） | CEF tarball → `Resources/` | ✅ 捆绑 |
+| | `icudtl.dat` | CEF tarball | ✅ 捆绑 |
+| | `locales/*.pak` | CEF tarball | ✅ 捆绑 |
+
+> **关键点**：`CEF_BINARY_FILES` 和 `CEF_RESOURCE_FILES` CMake 变量控制捆绑列表。`third/cef/` 全部 gitignored。所有 CEF 运行时文件平铺在 exe 同目录下。
+
+---
+
+### Linux
+
+#### 三阶段文件流转
+
+| 阶段 | 内容 | 来源 | 去向 |
+|------|------|------|------|
+| **远程拉取** | `cef_binary_*_linux64.tar.bz2` | Spotify CDN | 解压到 `third/cef/` |
+| **中间产物** | `libcef_dll_wrapper.a` | cmake 编译 CEF 包装器源码 | 链接进 `webview_cef_plugin.so` |
+| | `include/` + `cmake/` | 从 tarball 解压 | 仅编译时使用 |
+| **最终打包** | `libcef.so` | CEF tarball → `Release/` | ✅ `bundle/lib/` |
+| | `chrome-sandbox` | CEF tarball | ✅ `bundle/lib/` |
+| | `libEGL.so`、`libGLESv2.so` | CEF tarball | ✅ `bundle/lib/` |
+| | `*.pak` + `icudtl.dat` | CEF tarball → `Resources/` | ✅ `bundle/lib/` |
+| | `locales/*.pak` | CEF tarball | ✅ `bundle/lib/locales/` |
+| | `webview_cef_plugin.so` | 编译项目源码 | ✅ `bundle/lib/` |
+
+> **关键点**：所有 CEF 运行时文件统一放在 `bundle/lib/`。`third/cef/` 全部 gitignored。
+
+---
+
+### eLinux
+
+与 Linux 流程相同，区别：
+- 额外捆绑 `libflutter_elinux_<backend>.so`（Wayland / GBM / EGLStream / X11）
+- 无 GTK 依赖（纯 DRM/GBM/Wayland 环境）
+- `hasNativeKeySupport` 返回 `false`，键盘由 Dart 侧处理
+
+---
+
+### 各平台最终产物对照
+
+| | macOS | Windows | Linux | eLinux |
+|---|------|------|------|------|
+| **下载触发** | `pod install` → `download_cef.sh` | CMake → `download.cmake` | CMake → `download.cmake` | CMake → `download.cmake` |
+| **CEF 存放** | `macos/third/cef/` | `third/cef/` | `third/cef/` | `third/cef/` |
+| **参与打包** | framework + helper + wrapper(链接) | `libcef.dll` + dll + pak + dat + locales | `libcef.so` + sandbox + so + pak + dat + locales | 同 Linux |
+| **不进包** | `include/` + `version.txt` | `include/` + `cmake/` + wrapper 源码 | `include/` + `cmake/` + wrapper 源码 | 同 Linux |
+| **运行时位置** | `App.app/Contents/Frameworks/` | exe 同目录平铺 | `bundle/lib/` | `bundle/lib/` |
+
+---
+
 ## macOS
 
 ### 构建系统

--- a/docs/chapter/7-构建与集成.md
+++ b/docs/chapter/7-构建与集成.md
@@ -57,6 +57,10 @@ macOS 多进程模式（非单进程）需要捆绑 CEF Helper 应用。构建�
 
 如果没有 Helper 应用，运行时自动回退到单进程模式。
 
+### Universal 构建（arm64 + x86_64）
+
+默认情况下，`download_cef.sh` 会同时下载 arm64 和 x86_64 两个架构的 CEF 包，分别构建后用 `lipo` 合并为 fat binary。详细方案见 [macOS Universal 构建](8-macOS%20Universal构建.md)。
+
 ### 重新编译
 
 `common/` 中的 C++ 代码被编译到两个位置：

--- a/docs/chapter/7-构建与集成.md
+++ b/docs/chapter/7-构建与集成.md
@@ -9,7 +9,7 @@ CEF 标准发行版（包含 `Chromium Embedded Framework.framework`、`libcef_d
 | macOS | `macos/scripts/download_cef.sh` | `macos/third/cef/` |
 | Windows / Linux / eLinux | `third/download.cmake` | `third/cef/` |
 
-各平台的下载是幂等的 —— 如果目标版本已存在则跳过下载。
+各平台的下载是幂等的 —— 如果目标版本已存在则跳过下载。macOS 平台额外对 `cef_helper` 依赖的全部 `common/*.cc/.h` 源文件计算 SHA256 内容哈希并写入 stamp 文件，源码变更时哈希不匹配会自动触发重编。
 
 ---
 
@@ -59,13 +59,24 @@ macOS 多进程模式（非单进程）需要捆绑 CEF Helper 应用。构建�
 
 ### 重新编译
 
-修改 `common/` 中的 C++ 代码后：
+`common/` 中的 C++ 代码被编译到两个位置：
+
+| 编译目标 | 编译方式 | 运行位置 |
+|---------|---------|---------|
+| 主 App 插件库 | Xcode 编译 `cef_bridge.cc`（`flutter run` 自动触发） | Browser 进程 |
+| CEF Helper 子进程 | `download_cef.sh` 编译 `cef_helper` 二进制（`pod install` 时触发） | Renderer 进程 |
+
+因此修改 `common/` 中的 C++ 代码后，**两种方式都需要重新编译**：
 
 ```bash
-cd example && flutter run -d macos
+# 1. 重新编译 cef_helper（源码哈希变化 → download_cef.sh 自动检测并重编）
+cd example/macos && pod install
+
+# 2. 编译并运行主 App（Xcode 自动检测变化）
+cd .. && flutter run -d macos
 ```
 
-Xcode 会自动检测变化并重新编译。
+> **注意**：`download_cef.sh` 对 `cef_helper` 依赖的源文件（`common/webview_*.cc/.h` + `helper/cef_helper_main.mm`）计算 SHA256 内容哈希并写入 stamp 文件。任意源文件改动后，`pod install` 会自动检测哈希不匹配并触发重编。若不执行 `pod install`，Renderer 进程仍运行旧代码，可能导致 JS Bridge 等行为异常。
 
 ---
 

--- a/docs/chapter/7-构建与集成.md
+++ b/docs/chapter/7-构建与集成.md
@@ -1,0 +1,208 @@
+# 构建与集成
+
+## CEF 二进制管理
+
+CEF 标准发行版（包含 `Chromium Embedded Framework.framework`、`libcef_dll_wrapper`、资源文件等）通过以下机制按需下载：
+
+| 平台 | 下载脚本 | 目标目录 |
+|------|---------|---------|
+| macOS | `macos/scripts/download_cef.sh` | `macos/third/cef/` |
+| Windows / Linux / eLinux | `third/download.cmake` | `third/cef/` |
+
+各平台的下载是幂等的 —— 如果目标版本已存在则跳过下载。
+
+---
+
+## macOS
+
+### 构建系统
+
+使用 CocoaPods + Xcode。
+
+**Podspec**：`macos/webview_cef.podspec`
+
+```
+依赖：FlutterMacOS
+框架：Metal, CoreVideo, IOSurface
+供应商框架：third/cef/Chromium Embedded Framework.framework
+供应商库：third/cef/libcef_dll_wrapper.a
+C++ 标准：C++20
+平台要求：macOS 12.0+
+
+pod_target_xcconfig:
+  WEBVIEW_CEF_GPU_TEXTURE=1 (预处理器定义)
+  EXCLUDED_ARCHS = 非本机架构 (arm64 主机排除 x86_64)
+
+prepare_command: bash scripts/download_cef.sh
+```
+
+### 编译桥
+
+`macos/Classes/cef_bridge.cc` 通过 `#include` 直接引入所有 `common/` 源文件：
+
+```cpp
+#include "../../common/webview_app.cc"
+#include "../../common/webview_handler.cc"
+#include "../../common/webview_cookieVisitor.cc"
+#include "../../common/webview_js_handler.cc"
+#include "../../common/webview_plugin.cc"
+#include "../../common/webview_value.cc"
+```
+
+这样 Xcode 通过单个编译单元编译所有通用 C++ 源文件。
+
+### Helper 应用嵌入
+
+macOS 多进程模式（非单进程）需要捆绑 CEF Helper 应用。构建阶段（`embed_cef_helpers.rb`）将 Helper 应用复制到 `.app` bundle 中。
+
+如果没有 Helper 应用，运行时自动回退到单进程模式。
+
+### 重新编译
+
+修改 `common/` 中的 C++ 代码后：
+
+```bash
+cd example && flutter run -d macos
+```
+
+Xcode 会自动检测变化并重新编译。
+
+---
+
+## Windows
+
+### 构建系统
+
+CMake，最低版本 3.14。
+
+**主 CMakeLists**：`windows/CMakeLists.txt`
+
+```
+include ../third/download.cmake
+prepare_prebuilt_files()  → 下载 CEF
+
+set(USE_SANDBOX OFF)
+set(CEF_RUNTIME_LIBRARY_FLAG "/MD")
+
+构建 libcef_dll_wrapper
+编译 common/*.cc + windows/*.cpp
+
+WEBVIEW_CEF_GPU_TEXTURE (默认 ON) → 控制 GPU 渲染路径
+
+链接库：
+  flutter, flutter_wrapper_plugin
+  libcef_lib, libcef_dll_wrapper
+  imm32, comctl32, d3d11, dxgi
+```
+
+### 编译时标志
+
+| 标志 | 作用 |
+|------|------|
+| `WEBVIEW_CEF_GPU_TEXTURE` | 启用 D3D11 共享纹理 GPU 路径 |
+| `CEF_LIB_RELEASE` | 即使 Debug 构建也链接 CEF Release 二进制（避免 DCHECK 崩溃） |
+
+### 输出文件
+
+`webview_cef_bundled_libraries`：CEF 运行时文件（`.dll`、`.pak` 资源文件等）随插件捆绑。
+
+---
+
+## Linux
+
+### 构建系统
+
+CMake，最低版本 3.10，C++20。
+
+**主 CMakeLists**：`linux/CMakeLists.txt`
+
+```
+定义 HAS_GTK
+查找 GTK+3 库
+查找 xclip (剪贴板工具)
+
+与 Windows 相同的 CEF 下载/构建模式
+
+链接库：
+  flutter, flutter_wrapper_plugin
+  libcef_lib, libcef_dll_wrapper
+  gmodule-2.0, gtk+-3.0 (GTK)
+  GL
+
+rpath=$ORIGIN (CEF 共享库从可执行文件目录加载)
+```
+
+### 目标修改
+
+`linux/webview_cef_plugin.cc` 中的 `webview_cef_plugin_register_with_registrar()` 是 Flutter 自动生成代码的入口点。
+
+`target_modifier/modify_target.sh` 修改自动生成的 Flutter Linux 构建目标，添加键盘事件处理和 WebView 初始化调用。
+
+### 应用集成
+
+Linux 平台的 Flutter 应用需要：
+
+1. 在 `main()` 中调用 `initCEFProcesses(argc, argv)`
+2. 将 GTK 的 `key-press-event` 信号连接到 `processKeyEventForCEF()`
+
+---
+
+## eLinux
+
+### 构建系统
+
+CMake，最低版本 3.10，C++17。
+
+**主 CMakeLists**：`elinux/CMakeLists.txt`
+
+```
+使用 flutter_elinux 工具链
+使用 flutter 嵌入式 C++ 客户端包装器
+
+编译 common/*.cc + elinux/*.cpp
+Flutter 包装器源文件从 example/flutter/ephemeral 目录引入
+
+架构检测：CMAKE_SYSTEM_PROCESSOR
+链接：libcef_dll_wrapper, CEF_STANDARD_LIBS
+
+无 GTK 或 X11 依赖 — 使用 DRM/GBM/Wayland
+```
+
+### 特点
+
+- `hasNativeKeySupport` 返回 `false`，键盘由 Dart 侧处理
+- 仅支持软件渲染（无 GPU 共享纹理）
+
+---
+
+## pubspec.yaml 配置
+
+**文件**：`pubspec.yaml`
+
+```yaml
+version: 0.5.1
+environment:
+  sdk: ">=3.6.0"
+  flutter: ">=3.27.0"
+
+flutter:
+  plugin:
+    platforms:
+      macos:
+        pluginClass: WebviewCefPlugin
+      windows:
+        pluginClass: WebviewCefPluginCApi
+      linux:
+        pluginClass: WebviewCefPlugin
+      elinux:
+        pluginClass: WebviewCefPlugin
+```
+
+## 编译时标志参考
+
+| 标志 | 位置 | 作用 |
+|------|------|------|
+| `WEBVIEW_CEF_GPU_TEXTURE` | macOS podspec / Windows+Linux+eLinux CMake | 启用 GPU 零拷贝渲染，OnAcceleratedPaint 替代 OnPaint |
+| `HAS_GTK` | linux/CMakeLists.txt | 标识 GTK 平台，影响键处理代码路径 |
+| `OS_MAC` / `OS_WIN` / `OS_LINUX` | CEF 内置 | 平台条件编译 |
+| `DISALLOW_COPY_AND_ASSIGN` | CEF 内置宏 | 禁用拷贝构造函数和赋值运算符 |

--- a/docs/chapter/8-macOS Universal构建.md
+++ b/docs/chapter/8-macOS Universal构建.md
@@ -1,0 +1,214 @@
+# macOS Universal 构建
+
+> 让 `flutter build macos` 产出同时包含 arm64 和 x86_64 两种架构的 Universal App。
+
+## 背景与问题
+
+### 现状
+
+CEF 官方为 macOS 发布的二进制是按架构分开的——`macosarm64` 和 `macosx64` 各一个包，没有"双架构合体"版本。当前 `download_cef.sh` 只下载宿主架构的 CEF 包，`podspec` 通过 `EXCLUDED_ARCHS` 告诉 Xcode 排除非宿主架构，因此产出的 App 只能在和编译机器同架构的 Mac 上运行。
+
+### 目标
+
+无论在哪台 Mac 上构建，`flutter build macos --release` 都能产出 arm64 + x86_64 的 Universal App：
+
+```bash
+$ lipo -info Runner.app/Contents/MacOS/Runner
+Architectures in the fat file: Runner are: arm64 x86_64
+```
+
+### 核心思路
+
+同时下载 arm64 和 x86_64 两个 CEF 包 → 各自构建 → 用 `lipo -create` 合并成 fat binary → 去掉 `EXCLUDED_ARCHS`，让 Xcode 正常产出 Universal App。
+
+---
+
+## 需要合并哪些二进制
+
+CEF 发行版中需要合并的二进制文件共 **7 个**：
+
+| # | 文件 | 来源 | 合并方式 |
+|---|------|------|----------|
+| 1 | `Chromium Embedded Framework`（主 dylib） | CEF 官方包 | `lipo` |
+| 2 | `libEGL.dylib` | CEF 官方包 | `lipo` |
+| 3 | `libGLESv2.dylib` | CEF 官方包 | `lipo` |
+| 4 | `libvk_swiftshader.dylib` | CEF 官方包 | `lipo` |
+| 5 | `libcef_sandbox.dylib` | CEF 官方包 | `lipo` |
+| 6 | `libcef_dll_wrapper.a` | 自己 cmake 编译 | `lipo` |
+| 7 | `cef_helper` | 自己 clang++ 编译 | `lipo` |
+
+> Framework 内的 dylib 不硬编码文件名，而是用 `find` + `file` 扫描所有 Mach-O 文件后逐一合并，CEF 版本升级时自动适应。
+
+---
+
+## 最优方案：始终 Universal + 逃生口回退
+
+### 设计原则
+
+- **默认行为**：始终产出 Universal 二进制，不需要开关
+- **回退机制**：仅当显式设置 `CEF_UNIVERSAL=0` 时退回单架构（用于网络/磁盘紧张的紧急场景）
+- **核心目标**：本地开发、CI、所有 Mac 上跑完全一致的逻辑，消除代码分支
+
+### 方案选择理由
+
+| | 按需切换方案 | 始终 Universal 方案 | 最优方案（本方案） |
+|---|---|---|---|
+| 默认行为 | 单架构 | 双架构 | **双架构** |
+| 代码分支 | 多（脚本和 podspec 到处 if/else） | 无 | **极少（仅回退路径）** |
+| 本地 / CI 一致性 | ❌ 不一致 | ✅ 一致 | ✅ 一致 |
+| 日常 pod install 速度 | 快 | 首次慢，有缓存后秒级 | **本地 tarball 加速后接近单架构** |
+| 灵活性 | 高 | 低 | **中等（保留逃生口）** |
+| 维护成本 | 高（多路径测试矩阵） | 低 | **低** |
+
+---
+
+## 具体实现
+
+### 改哪些文件
+
+| 文件 | 改动内容 | 复杂度 |
+|------|---------|--------|
+| `macos/scripts/download_cef.sh` | 下载双架构 → 各自构建 → lipo 合并 | ⭐⭐⭐ |
+| `macos/webview_cef.podspec` | 删除 `EXCLUDED_ARCHS`，只保留回退路径下的排除逻辑 | ⭐⭐ |
+| `.github/workflows/test_macos.yaml` | 删除手动下载 CEF 的步骤 | ⭐ |
+
+不动的东西：
+- `embed_cef_helpers.sh` — 只是复制文件，文件已是 fat 的，无感
+- `third/download.cmake` — macOS 不走这个路径
+- `Runner.xcodeproj` — Debug 的 `ONLY_ACTIVE_ARCH = YES` 保留，本地调试仍只编宿主架构
+
+---
+
+### 一、`download_cef.sh` 改造
+
+#### 1.1 架构检测：默认双架构 + 回退
+
+```bash
+# 默认：始终下载两个架构
+# 回退：CEF_UNIVERSAL=0 时只下载宿主架构
+if [ "${CEF_UNIVERSAL:-}" = "0" ]; then
+  case "$(uname -m)" in
+    arm64)  ARCHES=("arm64") ;;
+    x86_64) ARCHES=("x86_64") ;;
+    *)      err "不支持的架构: $(uname -m)" ;;
+  esac
+else
+  ARCHES=("arm64" "x86_64")
+fi
+```
+
+> `CEF_UNIVERSAL=0` 不是日常切换选项，而是一个**逃生口**——仅在网络极差或磁盘紧张时使用。回退路径的 stamp 格式不同（单架构标识），下次不带 `CEF_UNIVERSAL=0` 跑时会自动检测到不匹配，触发重新构建 Universal。
+
+#### 1.2 抽成函数
+
+核心逻辑抽成 `download_and_build()` 函数，对每个架构调用一次。helper 在函数内部构建——arm64 的 helper 必须链接 arm64 的 wrapper，x86_64 的 helper 必须链接 x86_64 的 wrapper。原则是：各编各的，最后再合。
+
+#### 1.3 本地 tarball 加速
+
+```bash
+# 如果 cef_tar/ 目录下有对应架构的包，直接使用，跳过 CDN 下载
+local_tar="${REPO_ROOT}/cef_tar/${pkg}.tar.bz2"
+if [ -f "${local_tar}" ]; then
+  cp "${local_tar}" "${tarball}"
+else
+  # 正常 CDN 下载 + 重试逻辑
+fi
+```
+
+#### 1.4 lipo 合并
+
+- **libcef_dll_wrapper.a**：直接 `lipo -create`
+- **CEF Framework**：以 arm64 为基底复制框架结构，然后 `find` + `file` 扫描所有 Mach-O 文件逐一 lipo
+- **cef_helper**：`lipo -create` 两个单架构版本
+
+#### 1.5 关键细节
+
+- **Stamp 格式**：`{version}_arm64,x86_64_{build_type}_{source_hash}`（双架构）/ 保持旧格式（回退）
+- **is_fat 校验**：缓存命中时不仅检查 stamp，还验证关键文件确实是 fat binary，防止"半成品"缓存
+- **原子化写入 stamp**：`.tmp → mv` 方式
+- **临时目录**：固定命名 `_build_arm64` / `_build_x86_64`，退出时 `trap cleanup EXIT` 自动清理
+- **bash 3.2 兼容**：使用 `cef_arch_for()` 函数代替 `declare -A` 关联数组
+
+---
+
+### 二、`webview_cef.podspec` 改造
+
+**默认路径（Universal）**：删除 `EXCLUDED_ARCHS`。
+
+**回退路径**：仅当 `ENV['CEF_UNIVERSAL'] == '0'` 时恢复 `EXCLUDED_ARCHS`。
+
+```ruby
+universal_disabled = ENV['CEF_UNIVERSAL'] == '0'
+
+if universal_disabled
+  # 恢复 EXCLUDED_ARCHS 排除非宿主架构
+else
+  # 不设 EXCLUDED_ARCHS，Xcode 正常编译 Universal
+end
+```
+
+---
+
+### 三、CI Workflow 改造
+
+删除手动下载 CEF 的 step。`pod install` 已包含完整的下载 + 构建 + lipo 逻辑。CI 流程简化为：checkout → flutter setup → brew install → flutter analyze → flutter build macos。
+
+---
+
+## 验证清单
+
+### 首次构建验证
+
+```bash
+# 1. 清缓存
+rm -rf macos/third/cef
+
+# 2. 跑 pod install
+cd example/macos && pod install
+
+# 3. 检查 stamp
+cat macos/third/cef/version.txt
+# 期望包含 "arm64,x86_64"
+
+# 4. 检查 fat binary
+lipo -info macos/third/cef/libcef_dll_wrapper.a
+lipo -info macos/third/cef/cef_helper
+lipo -info "macos/third/cef/Chromium Embedded Framework.framework/Versions/A/Chromium Embedded Framework"
+# 每个都应显示: arm64 x86_64
+
+# 5. Debug 构建（ONLY_ACTIVE_ARCH = YES，只编宿主架构）
+flutter build macos --debug
+
+# 6. Release 构建（完整双架构）
+flutter build macos --release
+
+# 7. 验证 App
+lipo -info build/macos/Build/Products/Release/Runner.app/Contents/MacOS/Runner
+# → arm64 x86_64
+```
+
+### 缓存验证
+
+```bash
+cd example/macos && pod install
+# 期望：秒级完成，输出 "already prepared — nothing to do"
+```
+
+### 回退路径验证
+
+```bash
+rm -rf macos/third/cef
+CEF_UNIVERSAL=0 pod install
+# 产出单架构文件
+# 下次不带 CEF_UNIVERSAL=0 跑时自动重建 Universal
+```
+
+---
+
+## 注意事项
+
+- **磁盘空间**：临时目录峰值约 2GB，构建完成后自动清理
+- **首次构建时间**：使用本地 tarball（`cef_tar/`）时，跳过 CDN 下载，接近原单架构时间
+- **被中断的 pod install**：`trap cleanup EXIT` 自动清理临时目录，下次重新开始
+- **CEF 版本升级**：`find` + `file` 扫描机制自动适应 framework 内部结构变化
+- **Intel Mac 兼容**：脚本不再依赖 `uname -m` 决定下载哪个架构，Intel Mac 上 Debug 构建时链接器只取 x86_64 的 slice

--- a/docs/chapter/8-macOS Universal构建.md
+++ b/docs/chapter/8-macOS Universal构建.md
@@ -105,15 +105,20 @@ fi
 
 #### 1.3 本地 tarball 加速
 
+`download_cef.sh` 执行时会优先检查 `cef_tar/` 目录，如果存在对应架构的 tarball 则直接使用，跳过 CDN 下载：
+
 ```bash
-# 如果 cef_tar/ 目录下有对应架构的包，直接使用，跳过 CDN 下载
 local_tar="${REPO_ROOT}/cef_tar/${pkg}.tar.bz2"
 if [ -f "${local_tar}" ]; then
-  cp "${local_tar}" "${tarball}"
+  cp "${local_tar}" "${tarball}"       # 秒级，跳过下载
 else
-  # 正常 CDN 下载 + 重试逻辑
+  # CDN 下载 + 重试
 fi
 ```
+
+**如何预置 tarball**：从 Spotify CDN 下载后放入 `cef_tar/` 目录（详见 `cef_tar/README.md`），文件不会被提交到 Git（已通过 `.gitignore` 排除）。下次 `pod install` 时会自动识别并使用。
+
+**依赖方如何使用**：如果你是通过 Git 依赖 `webview_cef` 的项目，同样可以将 CEF tarball 放入插件的 `cef_tar/` 目录下。由于 Flutter 通过符号链接（`.symlinks/plugins/`）引用插件，插件源码中的 `cef_tar/` 路径仍然可达，脚本能正确找到本地文件。
 
 #### 1.4 lipo 合并
 
@@ -208,7 +213,8 @@ CEF_UNIVERSAL=0 pod install
 ## 注意事项
 
 - **磁盘空间**：临时目录峰值约 2GB，构建完成后自动清理
-- **首次构建时间**：使用本地 tarball（`cef_tar/`）时，跳过 CDN 下载，接近原单架构时间
+- **首次构建时间**：使用本地 tarball（`cef_tar/`）时，跳过 CDN 下载，接近原单架构时间。`cef_tar/` 下的文件不会被提交到 Git（`.gitignore` 已排除），需要手动下载放置。详见 `cef_tar/README.md`
+- **依赖方加速**：如果是依赖 `webview_cef` 的外部项目，可将 CEF tarball 放入插件源码目录的 `cef_tar/` 下（即 `<your_project>/.symlinks/plugins/webview_cef/cef_tar/`），即可享受本地加速
 - **被中断的 pod install**：`trap cleanup EXIT` 自动清理临时目录，下次重新开始
 - **CEF 版本升级**：`find` + `file` 扫描机制自动适应 framework 内部结构变化
 - **Intel Mac 兼容**：脚本不再依赖 `uname -m` 决定下载哪个架构，Intel Mac 上 Debug 构建时链接器只取 x86_64 的 slice

--- a/docs/chapter/9-CEF详解.md
+++ b/docs/chapter/9-CEF详解.md
@@ -1,0 +1,270 @@
+# CEF 详解
+
+CEF（Chromium Embedded Framework）是本项目的核心依赖，提供实际的网页渲染能力。本文说明 CEF 自身的文件、进程和运行机制。
+
+## CEF 是什么
+
+CEF 是 Chromium 浏览器的嵌入式框架包装。它将 Chromium 内核封装为一组稳定的 C API，允许桌面应用嵌入完整的 Web 浏览器。CEF 版本紧跟 Chromium 发布节奏，本项目当前使用 CEF 149（对应 Chromium 149）。
+
+## CEF 相关文件
+
+### 核心文件
+
+| 文件 | 说明 |
+|------|------|
+| `Chromium Embedded Framework.framework` | CEF 主框架，包含 browser 进程所需的全部可执行代码和资源 |
+| `libcef_dll_wrapper.a` | C API 的 C++ 适配层（`CefRefPtr`、`CefString` 等），编译为静态库 |
+| `cef_sandbox.a` | Chromium 沙箱库（仅 Windows） |
+| `icudtl.dat` | ICU 国际化数据（Unicode、时区、字符编码） |
+| `*.pak` / `*.bin` | Chromium 资源文件（UI 资源、本地化字符串、Blink 渲染引擎资源等） |
+| `snapshot_blob.bin` / `v8_context_snapshot.bin` | V8 引擎快照，加速 JS 上下文创建 |
+
+### macOS Helper 应用
+
+macOS 上 CEF 以**子进程**方式运行渲染、GPU 等工作。每个子进程类型对应一个独立的 `.app` bundle：
+
+```
+<AppName> Helper.app          — 渲染进程（Renderer）
+<AppName> Helper (GPU).app    — GPU 进程
+<AppName> Helper (Plugin).app — 插件进程（Flash 等，已废弃）
+<AppName> Helper (Alerts).app — 通知/弹窗进程
+```
+
+这些 Helper 应用由构建脚本（`macos/scripts/embed_cef_helpers.rb`）在编译阶段复制到主 App 的 `Contents/Frameworks/` 目录下。每个 Helper 内部编译了一份精简的 `cef_helper` 二进制，链接了 `common/` 中的 JS 桥接代码（因为 JS ↔ C++ 桥接在渲染进程中运行）。
+
+### 目录结构（macOS 典型）
+
+```
+webview_cef/macos/third/cef/
+├── Chromium Embedded Framework.framework/
+│   ├── Chromium Embedded Framework   ← 主动态库（~1GB）
+│   ├── Resources/                    ← pak、icudtl.dat、本地化资源
+│   └── Libraries/
+│       └── libcef_dll_wrapper.a
+├── cef_helper                        ← Helper 应用编译产物
+├── include/                          ← C API 头文件
+│   ├── cef_client.h
+│   ├── cef_browser.h
+│   ├── cef_render_handler.h
+│   └── ...
+└── Release/                          ← macOS release 构建输出
+```
+
+Web App 运行时的 Frameworks 目录：
+
+```
+<AppName>.app/
+└── Contents/
+    └── Frameworks/
+        ├── Chromium Embedded Framework.framework/
+        ├── <AppName> Helper.app/                    ← 渲染进程
+        │   └── Contents/MacOS/<AppName> Helper
+        ├── <AppName> Helper (GPU).app/              ← GPU 进程
+        │   └── Contents/MacOS/<AppName> Helper (GPU)
+        ├── FlutterMacOS.framework/
+        └── webview_cef.framework/
+```
+
+## CEF 多进程架构
+
+CEF 继承了 Chromium 的多进程架构，所有进程通过 IPC（进程间通信）协同工作。
+
+### 进程类型
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Browser 进程（主进程）                                        │
+│  - CEF 应用入口，持有 CefSettings、CefApp、CefClient           │
+│  - 管理浏览器窗口生命周期                                       │
+│  - 处理平台 UI 消息循环（macOS: external_message_pump）          │
+│  - 路由 IPC 消息到各子进程                                      │
+│  - 运行 CefBrowserProcessHandler                               │
+├──────────────────────────────────────────────────────────────┤
+│  Renderer 进程（渲染进程）                                      │
+│  - 运行 Blink 渲染引擎 + V8 JavaScript 引擎                     │
+│  - 解析 HTML/CSS、执行 JavaScript、构建 DOM、布局、绘制          │
+│  - 运行 CefRenderProcessHandler（含 V8 扩展、JS 桥接）          │
+│  - 每个站点/标签页各一个（取决于 ProcessMode）                  │
+│  - 沙箱隔离，崩溃不影响主进程                                    │
+├──────────────────────────────────────────────────────────────┤
+│  GPU 进程                                                      │
+│  - 处理 OpenGL/Metal/D3D 图形合成                               │
+│  - OnAcceleratedPaint 共享纹理的源头                            │
+│  - 本项目 GPU 纹理渲染路径的关键进程                             │
+│  - 崩溃后自动重启，不影响 Browser 进程                          │
+├──────────────────────────────────────────────────────────────┤
+│  Network 进程（网络服务）                                       │
+│  - 处理所有 HTTP/HTTPS 请求                                     │
+│  - Cookie 存储和管理                                            │
+│  - DNS 解析、缓存                                               │
+├──────────────────────────────────────────────────────────────┤
+│  Utility 进程                                                   │
+│  - 音频解码、视频解码、数据解码等                                │
+│  - 证书验证、代理解析等辅助任务                                  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 进程启动时序
+
+```
+1. 主进程调用 CefInitialize()
+   ├── 初始化 Browser 进程
+   ├── 启动 GPU 进程
+   ├── 启动 Network 进程
+   └── 启动其他 Utility 进程
+         │
+2. 调用 CefBrowserHost::CreateBrowser() / CreateBrowserSync()
+   └── 启动 Renderer 进程
+         │
+3. Renderer 进程启动
+   ├── CefExecuteProcess() 入口
+   ├── 加载 V8 扩展（WebviewApp::OnWebKitInitialized）
+   ├── 创建渲染窗口（OSR: 离屏渲染，无原生窗口）
+   └── OnContextCreated → 页面 JavaScript 开始执行
+```
+
+### macOS 上的子进程启动
+
+macOS 的 CEF 子进程并非直接 `fork()`，而是通过**启动独立的 Helper 应用**实现：
+
+1. 主 App 在 `startCEF()` 中通过 `CefSettings.browser_subprocess_path` 指定 Helper 应用的路径
+2. 当需要 Renderer/GPU 进程时，CEF 内部调用 `NSTask` 启动对应 Helper 的二进制
+3. Helper 进程入口调用 `CefExecuteProcess()`，检查命令行 `--type` 参数确定自己的角色
+4. 通过 CEF 内部的 IPC 通道连接到主 Browser 进程
+
+代码路径（macOS）：
+
+```objc
+// CefWrapper.mm  — 设置子进程路径
+NSString* subprocessPath = [NSString stringWithFormat:
+    @"%@/%@.app/Contents/MacOS/%@", frameworksDir, helperName, helperName];
+webview_cef::setMacCEFPaths(subprocessPath, frameworkDir, mainBundlePath);
+
+// webview_plugin.cc  — startCEF() 传递路径给 CEF
+if (!g_macSubprocessPath.empty()) {
+    CefString(&cefs.browser_subprocess_path) = g_macSubprocessPath;
+}
+
+// CEF 内部 — 需要 Renderer 进程时启动 Helper
+// NSTask launch → <AppName> Helper.app/Contents/MacOS/<AppName> Helper
+// → CefExecuteProcess() → 检查 --type=renderer → 进入渲染进程逻辑
+```
+
+### CefExecuteProcess 的作用
+
+`CefExecuteProcess(mainArgs, app, nullptr)` 是子进程的入口函数：
+
+- **主进程中调用**：返回 -1，表示"当前是 browser 进程，继续执行 CefInitialize()"
+- **子进程中调用**：返回 0（正常退出），表示"子进程已处理完毕，直接 exit"
+
+```cpp
+// common/webview_plugin.cc
+int initCEFProcesses() {
+    app = new WebviewApp();
+    return CefExecuteProcess(mainArgs, app, nullptr);
+    // Browser 进程返回 -1 → 继续 CefInitialize()
+    // 子进程返回 0 → 不执行后续代码，直接退出
+}
+```
+
+## CEF 渲染模式
+
+### 离屏渲染（OSR — Off-Screen Rendering）
+
+本项目使用离屏渲染模式（`windowless_rendering_enabled = true`，`SetAsWindowless(0)`）：
+
+- CEF 将网页渲染到帧缓冲区，不创建原生窗口
+- 每帧通过 `OnPaint`（软件）或 `OnAcceleratedPaint`（GPU 共享纹理）回调
+- 帧数据通过 Flutter Texture 机制嵌入到 Flutter widget 树
+
+```
+CEF Renderer 进程
+  │
+  ▼ 渲染帧
+CEF Browser 进程
+  │
+  ├── OnPaint(buffer, width, height)          ← 软件路径：BGRA 缓冲区
+  │   └── SwapBufferFromBgraToRgba → Flutter Texture
+  │
+  └── OnAcceleratedPaint(shared_handle, ...)  ← GPU 路径：IOSurface / D3D11 纹理
+      └── 零拷贝 → Flutter Texture
+```
+
+### 窗口模式（非本项目的默认模式）
+
+CEF 也支持创建原生窗口（`CefWindow::CreateTopLevelWindow`），直接嵌入到原生 UI 视图层级中。本项目不使用此模式，因为它无法融入 Flutter 的 widget 树。
+
+## CEF 缓存与数据目录
+
+### root_cache_path
+
+`CefSettings.root_cache_path` 指定 CEF 所有持久化数据的根目录。如果不设置，CEF 使用平台默认路径，**多个 CEF 实例可能产生文件锁冲突**。
+
+本项目在 `startCEF()` 中设置此路径，各平台自动推导默认值（详见 [Dart 层 API](2-Dart层API.md) 中 `cachePath` 参数的说明）。
+
+### 缓存目录结构
+
+```
+<root_cache_path>/
+├── Cache/              ← HTTP 缓存（CSS、JS、图片等）
+├── Code Cache/         ← V8 编译后的 JS 代码缓存
+├── GPUCache/           ← GPU 着色器编译缓存
+├── Local Storage/      ← Web Storage API 数据（localStorage）
+├── Cookies             ← Cookie 数据库（SQLite）
+├── Cookies-journal
+├── Network Persistent State  ← HTTP 缓存索引
+└── Preferences         ← 浏览器偏好设置
+```
+
+> **注意**：本项目通过 `disable-gpu-shader-disk-cache` 命令行参数禁用了 GPU 着色器磁盘缓存，避免在不指定 `cache-path` 时自动创建 `GPUCache` 目录。
+
+## CEF 消息泵
+
+### external_message_pump（macOS）
+
+macOS 上设置 `cefs.external_message_pump = true`，CEF 不创建自己的消息循环，而是由 App 的 `NSApplication` runloop 驱动：
+
+```cpp
+// 每 16ms 调用一次，由 NSTimer 驱动
+void doMessageLoopWork() {
+    CefDoMessageLoopWork();
+}
+```
+
+### multi_threaded_message_loop（Windows / Linux）
+
+其他平台使用 `cefs.multi_threaded_message_loop = true`，CEF 自己管理消息循环线程。
+
+## CEF 版本与兼容性
+
+| 项目 | 说明 |
+|------|------|
+| CEF 版本 | 149.0.4 |
+| Chromium 版本 | 149 |
+| 支持的 macOS | 12.0+ |
+| C++ 标准 | C++20 |
+| API 兼容 | CEF C API（`include/cef_*.h`），使用 `libcef_dll_wrapper` 做 C++ 包装 |
+
+## CEF 命令行开关
+
+本项目在 `WebviewApp::OnBeforeCommandLineProcessing()` 中设置以下关键开关：
+
+| 开关 | 作用 |
+|------|------|
+| `disable-gpu` / `disable-gpu-compositing` | 非 GPU 纹理构建时禁用 GPU（条件编译） |
+| `disable-web-security` | 允许跨域请求 |
+| `allow-running-insecure-content` | 允许在 HTTPS 页面中加载 HTTP 内容 |
+| `disable-gpu-shader-disk-cache` | 禁止 GPU 着色器缓存写入磁盘 |
+| `no-sandbox` | 禁用沙箱（所有平台） |
+| `process-per-site` | 按站点隔离渲染进程（ProcessMode 1） |
+| `process-per-tab` | 按标签隔离渲染进程（ProcessMode 2） |
+| `single-process` | 单进程模式（ProcessMode 3） |
+| `autoplay-policy=no-user-gesture-required` | 允许自动播放音视频 |
+| `use-mock-keychain` | macOS：使用模拟钥匙串（避免权限弹窗，仅调试用） |
+
+## 参考资料
+
+- [CEF 官方文档](https://bitbucket.org/chromiumembedded/cef/wiki/Home)
+- [Chromium 多进程架构](https://www.chromium.org/developers/design-documents/multi-process-architecture/)
+- [Chromium 进程模型](https://www.chromium.org/developers/design-documents/process-models/)
+- [CEF 通用用法](https://bitbucket.org/chromiumembedded/cef/wiki/GeneralUsage)

--- a/elinux/webview_cef_plugin.cc
+++ b/elinux/webview_cef_plugin.cc
@@ -7,8 +7,11 @@
 #include <flutter/standard_method_codec.h>
 #include <flutter/texture_registrar.h>
 
+#include <climits>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <unistd.h>
 #include <unordered_map>
 
 #include <webview_plugin.h>
@@ -160,6 +163,35 @@ class WebviewCefPlugin : public flutter::Plugin {
       auto renderer = std::make_shared<WebviewTextureRenderer>(texture_registrar_);
       return std::dynamic_pointer_cast<webview_cef::WebviewTexture>(renderer);
     });
+
+    // Derive a default CEF cache path from the executable name so that
+    // multiple apps embedding the same CEF framework each get their own
+    // isolated cache directory.  If the Dart layer provides a cachePath
+    // via initialize(), it will override this default in startCEF().
+    char exePath[PATH_MAX] = {};
+    ssize_t len = readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
+    std::string exeName = "webview_cef";  // fallback
+    if (len > 0) {
+      exePath[len] = '\0';
+      std::string fullPath(exePath);
+      size_t lastSlash = fullPath.find_last_of('/');
+      if (lastSlash != std::string::npos) {
+        exeName = fullPath.substr(lastSlash + 1);
+      }
+    }
+    const char* xdgCache = getenv("XDG_CACHE_HOME");
+    std::string cacheDir;
+    if (xdgCache && xdgCache[0]) {
+      cacheDir = xdgCache;
+    } else {
+      const char* home = getenv("HOME");
+      if (home && home[0]) {
+        cacheDir = std::string(home) + "/.cache";
+      }
+    }
+    if (!cacheDir.empty()) {
+      webview_cef::setCefCachePath(cacheDir + "/" + exeName + "/cef");
+    }
   }
 
   ~WebviewCefPlugin() override {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -102,6 +102,27 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
             });
           }
         });
+
+        final Set<JavascriptChannel> jsChannels = {
+          JavascriptChannel(
+              name: 'Print',
+              onMessageReceived: (JavascriptMessage message) {
+                debugPrint(message.message);
+                _controller.sendJavaScriptChannelCallBack(
+                    false,
+                    "{'code':'200','message':'print succeed!'}",
+                    message.callbackId,
+                    message.frameId);
+              }),
+        };
+
+        //normal JavaScriptChannels
+        _controller.setJavaScriptChannels(jsChannels);
+        //also you can build your own jssdk by execute JavaScript code to CEF
+        _controller.executeJavaScript("function abc(e){return 'abc:'+ e}");
+        _controller
+            .evaluateJavascript("abc('test')")
+            .then((value) => debugPrint(value));
       },
       onNavigateRequest: (controller, url) {
         debugPrint("onNavigateRequest => $url");
@@ -114,13 +135,13 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
         return NavigationPolicy.allow;
       },
       onProgressUpdated: (controller, progress) {
-        debugPrint("onProgressUpdated => ${(progress * 100).toStringAsFixed(0)}%");
+        debugPrint(
+            "onProgressUpdated => ${(progress * 100).toStringAsFixed(0)}%");
         // Update a progress indicator with the 0.0-1.0 value.
         _progressAnimController.value = progress;
       },
       onPageFailed: (controller, url, error) {
-        debugPrint(
-            "onPageFailed => url: $url, code: ${error.code}, "
+        debugPrint("onPageFailed => url: $url, code: ${error.code}, "
             "message: ${error.message}");
         // Hide progress on error.
         _showProgress = false;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,9 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
     });
 
     WebviewManager()
-        .initialize(userAgent: "test/userAgent")
+        .initialize(
+            userAgent: "test/userAgent",
+            processMode: ProcessMode.processPerSite)
         .then((value) async {
       _controller = WebviewManager().createWebView(
           loading: const Text("not initialized"),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,8 +15,7 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp>
-    with SingleTickerProviderStateMixin {
+class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   late WebViewController _controller;
   final _textController = TextEditingController();
   String title = "";
@@ -195,8 +194,10 @@ class _MyAppState extends State<MyApp>
               SizedBox(
                 height: 48,
                 child: MaterialButton(
-                  onPressed: () {
-                    _controller.goBack();
+                  onPressed: () async {
+                    if (await _controller.canGoBack()) {
+                      _controller.goBack();
+                    }
                   },
                   child: const Icon(Icons.arrow_left),
                 ),
@@ -204,8 +205,10 @@ class _MyAppState extends State<MyApp>
               SizedBox(
                 height: 48,
                 child: MaterialButton(
-                  onPressed: () {
-                    _controller.goForward();
+                  onPressed: () async {
+                    if (await _controller.canGoForward()) {
+                      _controller.goForward();
+                    }
                   },
                   child: const Icon(Icons.arrow_right),
                 ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -80,42 +80,20 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
     String url = "www.baidu.com";
     _textController.text = url;
     //unified interface for all platforms set user agent
-    _controller.setWebviewListener(WebviewEventsListener(
-      onTitleChanged: (t) {
-        setState(() {
-          title = t;
-        });
-      },
-      onUrlChanged: (url) {
-        _textController.text = url;
-        final Set<JavascriptChannel> jsChannels = {
-          JavascriptChannel(
-              name: 'Print',
-              onMessageReceived: (JavascriptMessage message) {
-                debugPrint(message.message);
-                _controller.sendJavaScriptChannelCallBack(
-                    false,
-                    "{'code':'200','message':'print succeed!'}",
-                    message.callbackId,
-                    message.frameId);
-              }),
-        };
-        //normal JavaScriptChannels
-        _controller.setJavaScriptChannels(jsChannels);
-        //also you can build your own jssdk by execute JavaScript code to CEF
-        _controller.executeJavaScript("function abc(e){return 'abc:'+ e}");
-        _controller
-            .evaluateJavascript("abc('test')")
-            .then((value) => debugPrint(value));
-      },
-      onLoadStart: (controller, url) {
-        debugPrint("onLoadStart => $url");
+    _controller.setWebviewListener(WebViewEventsListener(
+      onPageStarted: (controller, url) {
+        debugPrint("onPageStarted => $url");
         _progress = 0;
         _showProgress = true;
         _progressAnimController.forward(from: 0);
       },
-      onLoadEnd: (controller, url) {
-        debugPrint("onLoadEnd => $url");
+      onPageFinished: (controller, url) {
+        debugPrint("onPageFinished => $url");
+        controller.getTitle().then((t) {
+          if (t != null && mounted) {
+            setState(() => title = t);
+          }
+        });
         _progressAnimController.forward(from: 0).then((_) {
           if (mounted) {
             setState(() {
@@ -124,6 +102,29 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
             });
           }
         });
+      },
+      onNavigateRequest: (controller, url) {
+        debugPrint("onNavigateRequest => $url");
+        // Example: block navigation to certain domains
+        if (url.contains('spam.com')) {
+          debugPrint("Navigation to '$url' blocked.");
+          controller.stopLoading();
+          return NavigationPolicy.cancel;
+        }
+        return NavigationPolicy.allow;
+      },
+      onProgressUpdated: (controller, progress) {
+        debugPrint("onProgressUpdated => ${(progress * 100).toStringAsFixed(0)}%");
+        // Update a progress indicator with the 0.0-1.0 value.
+        _progressAnimController.value = progress;
+      },
+      onPageFailed: (controller, url, error) {
+        debugPrint(
+            "onPageFailed => url: $url, code: ${error.code}, "
+            "message: ${error.message}");
+        // Hide progress on error.
+        _showProgress = false;
+        _progress = 0;
       },
     ));
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:webview_cef/webview_cef.dart';
@@ -135,6 +136,18 @@ class _MyAppState extends State<MyApp>
     if (!mounted) return;
   }
 
+  void _loadLocalHtml() {
+    final file = File(
+      '${Directory.current.path}'
+      '${Platform.pathSeparator}..'
+      '${Platform.pathSeparator}web-playground'
+      '${Platform.pathSeparator}bridge.html',
+    ).absolute;
+    final fileUrl = file.uri.toString();
+    _controller.loadUrl(fileUrl);
+    _textController.text = fileUrl;
+  }
+
   void _showInfoAlert(BuildContext context) {
     showDialog(
       context: context,
@@ -215,6 +228,13 @@ class _MyAppState extends State<MyApp>
                     },
                     child: const Icon(Icons.info_outline),
                   ),
+                ),
+              ),
+              SizedBox(
+                height: 48,
+                child: MaterialButton(
+                  onPressed: _loadLocalHtml,
+                  child: const Icon(Icons.file_open),
                 ),
               ),
               Expanded(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,7 +125,7 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
 
       // Must initialize the browser before setting channels or marking ready.
       _textController.text = "www.baidu.com";
-      await _controller!.initialize(_textController.text);
+      await _controller!.initialize(url: _textController.text);
 
       setState(() {
         _webViewInitialized = true;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,8 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
-  late WebViewController _controller;
+  WebViewController? _controller;
+  bool _webViewInitialized = false;
   final _textController = TextEditingController();
   String title = "";
   Map allCookies = {};
@@ -59,102 +60,103 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
       });
     });
 
-    _controller = WebviewManager().createWebView(
-        loading: const Text("not initialized"),
-        injectUserScripts: injectUserScripts);
+    WebviewManager()
+        .initialize(userAgent: "test/userAgent")
+        .then((value) async {
+      _controller = WebviewManager().createWebView(
+          loading: const Text("not initialized"),
+          injectUserScripts: injectUserScripts);
+
+      // Register event listener before initialize so that onPageStarted,
+      // onPageFinished, etc. are captured from the very first navigation.
+      _controller!.setWebviewListener(WebViewEventsListener(
+        onPageStarted: (controller, url) {
+          debugPrint("onPageStarted => $url");
+          _progress = 0;
+          _showProgress = true;
+          _progressAnimController.forward(from: 0);
+        },
+        onPageFinished: (controller, url) {
+          debugPrint("onPageFinished => $url");
+          controller.getTitle().then((t) {
+            if (t != null && mounted) {
+              setState(() => title = t);
+            }
+          });
+          _progressAnimController.forward(from: 0).then((_) {
+            if (mounted) {
+              setState(() {
+                _showProgress = false;
+                _progress = 0;
+              });
+            }
+          });
+
+          //also you can build your own jssdk by execute JavaScript code to CEF
+          _controller!.executeJavaScript("function abc(e){return 'abc:'+ e}");
+          _controller!
+              .evaluateJavascript("abc('test')")
+              .then((value) => debugPrint(value));
+        },
+        onNavigateRequest: (controller, url) {
+          debugPrint("onNavigateRequest => $url");
+          // Example: block navigation to certain domains
+          if (url.contains('spam.com')) {
+            debugPrint("Navigation to '$url' blocked.");
+            controller.stopLoading();
+            return NavigationPolicy.cancel;
+          }
+          return NavigationPolicy.allow;
+        },
+        onProgressUpdated: (controller, progress) {
+          debugPrint(
+              "onProgressUpdated => ${(progress * 100).toStringAsFixed(0)}%");
+          // Update a progress indicator with the 0.0-1.0 value.
+          _progressAnimController.value = progress;
+        },
+        onPageFailed: (controller, url, error) {
+          debugPrint("onPageFailed => url: $url, code: ${error.code}, "
+              "message: ${error.message}");
+          // Hide progress on error.
+          _showProgress = false;
+          _progress = 0;
+        },
+      ));
+
+      // Must initialize the browser before setting channels or marking ready.
+      _textController.text = "www.baidu.com";
+      await _controller!.initialize(_textController.text);
+
+      setState(() {
+        _webViewInitialized = true;
+      });
+
+      final Set<JavascriptChannel> jsChannels = {
+        JavascriptChannel(
+            name: 'Print',
+            onMessageReceived: (JavascriptMessage message) {
+              debugPrint(message.message);
+              _controller!.sendJavaScriptChannelCallBack(
+                  false,
+                  "{'code':'200','message':'print succeed!'}",
+                  message.callbackId,
+                  message.frameId);
+            }),
+      };
+
+      //normal JavaScriptChannels
+      await _controller!.setJavaScriptChannels(jsChannels);
+    });
+
     super.initState();
-    initPlatformState();
   }
 
   @override
   void dispose() {
     _progressAnimController.dispose();
-    _controller.dispose();
+    _controller?.dispose();
     WebviewManager().quit();
     super.dispose();
-  }
-
-  // Platform messages are asynchronous, so we initialize in an async method.
-  Future<void> initPlatformState() async {
-    await WebviewManager().initialize(userAgent: "test/userAgent");
-    String url = "www.baidu.com";
-    _textController.text = url;
-    //unified interface for all platforms set user agent
-    _controller.setWebviewListener(WebViewEventsListener(
-      onPageStarted: (controller, url) {
-        debugPrint("onPageStarted => $url");
-        _progress = 0;
-        _showProgress = true;
-        _progressAnimController.forward(from: 0);
-      },
-      onPageFinished: (controller, url) {
-        debugPrint("onPageFinished => $url");
-        controller.getTitle().then((t) {
-          if (t != null && mounted) {
-            setState(() => title = t);
-          }
-        });
-        _progressAnimController.forward(from: 0).then((_) {
-          if (mounted) {
-            setState(() {
-              _showProgress = false;
-              _progress = 0;
-            });
-          }
-        });
-
-        final Set<JavascriptChannel> jsChannels = {
-          JavascriptChannel(
-              name: 'Print',
-              onMessageReceived: (JavascriptMessage message) {
-                debugPrint(message.message);
-                _controller.sendJavaScriptChannelCallBack(
-                    false,
-                    "{'code':'200','message':'print succeed!'}",
-                    message.callbackId,
-                    message.frameId);
-              }),
-        };
-
-        //normal JavaScriptChannels
-        _controller.setJavaScriptChannels(jsChannels);
-        //also you can build your own jssdk by execute JavaScript code to CEF
-        _controller.executeJavaScript("function abc(e){return 'abc:'+ e}");
-        _controller
-            .evaluateJavascript("abc('test')")
-            .then((value) => debugPrint(value));
-      },
-      onNavigateRequest: (controller, url) {
-        debugPrint("onNavigateRequest => $url");
-        // Example: block navigation to certain domains
-        if (url.contains('spam.com')) {
-          debugPrint("Navigation to '$url' blocked.");
-          controller.stopLoading();
-          return NavigationPolicy.cancel;
-        }
-        return NavigationPolicy.allow;
-      },
-      onProgressUpdated: (controller, progress) {
-        debugPrint(
-            "onProgressUpdated => ${(progress * 100).toStringAsFixed(0)}%");
-        // Update a progress indicator with the 0.0-1.0 value.
-        _progressAnimController.value = progress;
-      },
-      onPageFailed: (controller, url, error) {
-        debugPrint("onPageFailed => url: $url, code: ${error.code}, "
-            "message: ${error.message}");
-        // Hide progress on error.
-        _showProgress = false;
-        _progress = 0;
-      },
-    ));
-
-    await _controller.initialize(_textController.text);
-
-    // If the widget was removed from the tree while the asynchronous platform
-    // message was in flight, we want to discard the reply rather than calling
-    // setState to update our non-existent appearance.
-    if (!mounted) return;
   }
 
   void _loadLocalHtml() {
@@ -165,7 +167,7 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
       '${Platform.pathSeparator}bridge.html',
     ).absolute;
     final fileUrl = file.uri.toString();
-    _controller.loadUrl(fileUrl);
+    _controller?.loadUrl(fileUrl);
     _textController.text = fileUrl;
   }
 
@@ -208,7 +210,7 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
                 height: 48,
                 child: MaterialButton(
                   onPressed: () {
-                    _controller.reload();
+                    _controller?.reload();
                   },
                   child: const Icon(Icons.refresh),
                 ),
@@ -217,8 +219,8 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
                 height: 48,
                 child: MaterialButton(
                   onPressed: () async {
-                    if (await _controller.canGoBack()) {
-                      _controller.goBack();
+                    if (await _controller!.canGoBack()) {
+                      _controller!.goBack();
                     }
                   },
                   child: const Icon(Icons.arrow_left),
@@ -228,8 +230,8 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
                 height: 48,
                 child: MaterialButton(
                   onPressed: () async {
-                    if (await _controller.canGoForward()) {
-                      _controller.goForward();
+                    if (await _controller!.canGoForward()) {
+                      _controller!.goForward();
                     }
                   },
                   child: const Icon(Icons.arrow_right),
@@ -239,7 +241,7 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
                 height: 48,
                 child: MaterialButton(
                   onPressed: () {
-                    _controller.openDevTools();
+                    _controller!.openDevTools();
                   },
                   child: const Icon(Icons.developer_mode),
                 ),
@@ -266,7 +268,7 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
                 child: TextField(
                   controller: _textController,
                   onSubmitted: (url) {
-                    _controller.loadUrl(url);
+                    _controller!.loadUrl(url);
                     WebviewManager().visitAllCookies().then((value) {
                       allCookies = Map.of(value);
                       if (url == "baidu.com") {
@@ -288,14 +290,18 @@ class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
             children: [
               Row(
                 children: [
-                  ValueListenableBuilder(
-                    valueListenable: _controller,
-                    builder: (context, value, child) {
-                      return _controller.value
-                          ? Expanded(child: _controller.webviewWidget)
-                          : _controller.loadingWidget;
-                    },
-                  ),
+                  // ValueListenableBuilder(
+                  //   valueListenable: _controller!,
+                  //   builder: (context, value, child) {
+                  //     return _controller!.value
+                  //         ? Expanded(child: _controller!.webviewWidget)
+                  //         : _controller!.loadingWidget;
+                  //   },
+                  // ),
+                  Expanded(
+                      child: _webViewInitialized
+                          ? _controller!.webviewWidget
+                          : Container()),
                 ],
               ),
               // Progress bar overlay on z-axis above the WebView

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,11 +14,17 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp>
+    with SingleTickerProviderStateMixin {
   late WebViewController _controller;
   final _textController = TextEditingController();
   String title = "";
   Map allCookies = {};
+
+  // Progress bar
+  late AnimationController _progressAnimController;
+  double _progress = 0;
+  bool _showProgress = false;
 
   @override
   void initState() {
@@ -43,6 +49,16 @@ class _MyAppState extends State<MyApp> {
     //   ScriptInjectTime.LOAD_END,
     // ));
 
+    _progressAnimController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    _progressAnimController.addListener(() {
+      setState(() {
+        _progress = _progressAnimController.value;
+      });
+    });
+
     _controller = WebviewManager().createWebView(
         loading: const Text("not initialized"),
         injectUserScripts: injectUserScripts);
@@ -52,6 +68,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
+    _progressAnimController.dispose();
     _controller.dispose();
     WebviewManager().quit();
     super.dispose();
@@ -93,9 +110,20 @@ class _MyAppState extends State<MyApp> {
       },
       onLoadStart: (controller, url) {
         debugPrint("onLoadStart => $url");
+        _progress = 0;
+        _showProgress = true;
+        _progressAnimController.forward(from: 0);
       },
       onLoadEnd: (controller, url) {
         debugPrint("onLoadEnd => $url");
+        _progressAnimController.forward(from: 0).then((_) {
+          if (mounted) {
+            setState(() {
+              _showProgress = false;
+              _progress = 0;
+            });
+          }
+        });
       },
     ));
 
@@ -105,6 +133,27 @@ class _MyAppState extends State<MyApp> {
     // message was in flight, we want to discard the reply rather than calling
     // setState to update our non-existent appearance.
     if (!mounted) return;
+  }
+
+  void _showInfoAlert(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          backgroundColor: Colors.white.withAlpha(230),
+          title: const Text('Title'),
+          content: const Text('Message'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('确认'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override
@@ -157,6 +206,17 @@ class _MyAppState extends State<MyApp> {
                   child: const Icon(Icons.developer_mode),
                 ),
               ),
+              Builder(
+                builder: (scaffoldContext) => SizedBox(
+                  height: 48,
+                  child: MaterialButton(
+                    onPressed: () {
+                      _showInfoAlert(scaffoldContext);
+                    },
+                    child: const Icon(Icons.info_outline),
+                  ),
+                ),
+              ),
               Expanded(
                 child: TextField(
                   controller: _textController,
@@ -179,16 +239,36 @@ class _MyAppState extends State<MyApp> {
             ],
           ),
           Expanded(
-              child: Row(
+              child: Stack(
             children: [
-              ValueListenableBuilder(
-                valueListenable: _controller,
-                builder: (context, value, child) {
-                  return _controller.value
-                      ? Expanded(child: _controller.webviewWidget)
-                      : _controller.loadingWidget;
-                },
+              Row(
+                children: [
+                  ValueListenableBuilder(
+                    valueListenable: _controller,
+                    builder: (context, value, child) {
+                      return _controller.value
+                          ? Expanded(child: _controller.webviewWidget)
+                          : _controller.loadingWidget;
+                    },
+                  ),
+                ],
               ),
+              // Progress bar overlay on z-axis above the WebView
+              if (_showProgress)
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  child: SizedBox(
+                    height: 3,
+                    child: LinearProgressIndicator(
+                      value: _progress,
+                      backgroundColor: Colors.transparent,
+                      valueColor: const AlwaysStoppedAnimation<Color>(
+                          Colors.blueAccent),
+                    ),
+                  ),
+                ),
             ],
           ))
         ],

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -185,14 +185,8 @@ class WebViewController extends ValueNotifier<bool> {
       return;
     }
     assert(value);
-    return _pluginChannel.invokeMethod('sendKeyEvent', [
-      _browserId,
-      type,
-      keyCode,
-      modifiers,
-      character,
-      unmodifiedCharacter
-    ]);
+    return _pluginChannel.invokeMethod('sendKeyEvent',
+        [_browserId, type, keyCode, modifiers, character, unmodifiedCharacter]);
   }
 
   Future<void> setJavaScriptChannels(Set<JavascriptChannel> channels) async {
@@ -380,7 +374,17 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     super.initState();
     _controller._onFocusedNodeChangeMessage = (editable) {
       _composingText = '';
-      editable ? attachTextInputClient() : detachTextInputClient();
+      if (editable) {
+        // Ensure CEF knows Flutter has focus before attaching text input.
+        // This is necessary after page reload: the FocusNode may still hold
+        // focus (so onFocusChange won't fire again), but CEF's internal
+        // keyboard focus state was reset during the reload. Without this
+        // call, text input won't work until Flutter focus is toggled off/on.
+        _controller.setClientFocus(true);
+        attachTextInputClient();
+      } else {
+        detachTextInputClient();
+      }
       _controller._focusEditable = editable;
     };
 
@@ -439,10 +443,10 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     // Map Flutter key event to CEF key event
     final logicalKey = event.logicalKey;
     final character = event.character;
-    
+
     // Convert logical key to Windows keycode
     int keyCode = _logicalKeyToWindowsKeyCode(logicalKey);
-    
+
     // Build modifiers
     int modifiers = 0;
     if (HardwareKeyboard.instance.isShiftPressed) {
@@ -454,7 +458,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     if (HardwareKeyboard.instance.isAltPressed) {
       modifiers |= eventFlagAltDown;
     }
-    
+
     // Determine event type
     int type;
     if (event is KeyDownEvent) {
@@ -464,7 +468,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     } else {
       return KeyEventResult.ignored;
     }
-    
+
     // Send key event to CEF
     _controller.sendKeyEvent(
       type,
@@ -473,7 +477,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
       character?.codeUnitAt(0) ?? 0,
       character?.codeUnitAt(0) ?? 0,
     );
-    
+
     // Send CHAR event after RAWKEYDOWN when character is present (required for text entry)
     if (event is KeyDownEvent && character != null) {
       _controller.sendKeyEvent(
@@ -516,7 +520,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     if (key == LogicalKeyboardKey.arrowDown) return 0x28;
     if (key == LogicalKeyboardKey.arrowLeft) return 0x25;
     if (key == LogicalKeyboardKey.arrowRight) return 0x27;
-    
+
     // For alphanumeric keys, use the key label
     final keyLabel = key.keyLabel;
     if (keyLabel.length == 1) {
@@ -530,7 +534,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
         return charCode;
       }
     }
-    
+
     // Default fallback
     return 0;
   }

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -144,6 +144,28 @@ class WebViewController extends ValueNotifier<bool> {
     return _pluginChannel.invokeMethod('goBack', _browserId);
   }
 
+  /// Returns whether the browser can navigate backward.
+  Future<bool> canGoBack() async {
+    if (_isDisposed) {
+      return false;
+    }
+    assert(value);
+    return _pluginChannel
+        .invokeMethod<bool>('canGoBack', _browserId)
+        .then((v) => v ?? false);
+  }
+
+  /// Returns whether the browser can navigate forward.
+  Future<bool> canGoForward() async {
+    if (_isDisposed) {
+      return false;
+    }
+    assert(value);
+    return _pluginChannel
+        .invokeMethod<bool>('canGoForward', _browserId)
+        .then((v) => v ?? false);
+  }
+
   Future<void> openDevTools() async {
     if (_isDisposed) {
       return;

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -74,7 +74,7 @@ class WebViewController extends ValueNotifier<bool> {
       _onImeCompositionRangeChangedMessage;
 
   /// Initializes the underlying platform view.
-  Future<void> initialize(String url) async {
+  Future<void> initialize({String url = "about:blank"}) async {
     if (_isDisposed) {
       return Future<void>.value();
     }

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -357,7 +357,8 @@ class WebView extends StatefulWidget {
   WebViewState createState() => WebViewState();
 }
 
-class WebViewState extends State<WebView> with WebeViewTextInput {
+class WebViewState extends State<WebView>
+    with WebeViewTextInput, WidgetsBindingObserver {
   final GlobalKey _key = GlobalKey();
   String _composingText = '';
   late final _focusNode = FocusNode();
@@ -412,6 +413,7 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _controller._onFocusedNodeChangeMessage = (editable) {
       _composingText = '';
       if (editable) {
@@ -471,6 +473,22 @@ class WebViewState extends State<WebView> with WebeViewTextInput {
     // Report initial surface size
     WidgetsBinding.instance
         .addPostFrameCallback((_) => _reportSurfaceSize(context));
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    // Window / screen metrics changed (e.g. resize, DPI change). Report the
+    // new surface size to CEF so the browser view rect stays in sync with the
+    // Flutter widget. This is a more reliable signal than
+    // SizeChangedLayoutNotifier during macOS live resize, where Flutter's
+    // layout pipeline may be throttled.
+    _reportSurfaceSize(context);
   }
 
   KeyEventResult _onKeyEvent(FocusNode node, KeyEvent event) {

--- a/lib/src/webview.dart
+++ b/lib/src/webview.dart
@@ -54,8 +54,8 @@ class WebViewController extends ValueNotifier<bool> {
   final Map<String, JavascriptChannel> _javascriptChannels =
       <String, JavascriptChannel>{};
   Map<String, JavascriptChannel> get javascriptChannels => _javascriptChannels;
-  WebviewEventsListener? _listener;
-  WebviewEventsListener? get listener => _listener;
+  WebViewEventsListener? _listener;
+  WebViewEventsListener? get listener => _listener;
 
   get onJavascriptChannelMessage => (final String channelName,
           final String message, final String callbackId, final String frameId) {
@@ -95,7 +95,7 @@ class WebViewController extends ValueNotifier<bool> {
     return _creatingCompleter.future;
   }
 
-  setWebviewListener(WebviewEventsListener listener) {
+  setWebviewListener(WebViewEventsListener listener) {
     _listener = listener;
   }
 
@@ -172,6 +172,24 @@ class WebViewController extends ValueNotifier<bool> {
     }
     assert(value);
     return _pluginChannel.invokeMethod('openDevTools', _browserId);
+  }
+
+  /// Returns the current page title, or `null` if unavailable.
+  Future<String?> getTitle() async {
+    if (_isDisposed) {
+      return null;
+    }
+    assert(value);
+    return _pluginChannel.invokeMethod<String>('getTitle', _browserId);
+  }
+
+  /// Stops the current page load.
+  Future<void> stopLoading() async {
+    if (_isDisposed) {
+      return;
+    }
+    assert(value);
+    return _pluginChannel.invokeMethod('stopLoading', _browserId);
   }
 
   Future<void> imeSetComposition(String composingText) async {

--- a/lib/src/webview_events_listener.dart
+++ b/lib/src/webview_events_listener.dart
@@ -1,7 +1,50 @@
 import 'package:webview_cef/src/webview.dart';
 
-typedef TitleChangeCb = void Function(String title);
-typedef UrlChangeCb = void Function(String url);
+/// Decides whether to allow or cancel a navigation request.
+enum NavigationPolicy {
+  /// Cancel the navigation.
+  cancel,
+
+  /// Allow the navigation to proceed.
+  allow,
+}
+
+/// Error information passed to [PageErrorCallback].
+class WebViewError {
+  const WebViewError(this.code, this.message, [this.extraInfo]);
+
+  /// CEF error code (e.g. ERR_ABORTED, ERR_NAME_NOT_RESOLVED).
+  final int code;
+
+  /// Localized error description.
+  final String message;
+
+  /// Additional error context. Includes "url" key with the failing URL.
+  final Map<String, dynamic>? extraInfo;
+}
+
+/// Called before a navigation starts. Return [NavigationPolicy.cancel] to
+/// reject the navigation; follow up with [WebViewController.stopLoading]
+/// to actually abort it.
+typedef PageNavigationDelegate = NavigationPolicy Function(
+    WebViewController controller, String url);
+
+/// Called when a page has started loading.
+typedef PageStartedCallback = void Function(
+    WebViewController controller, String url);
+
+/// Called when a page has finished loading.
+typedef PageFinishedCallback = void Function(
+    WebViewController controller, String url);
+
+/// Called as page load progress updates.
+typedef PageProgressCallback = void Function(
+    WebViewController controller, double progress);
+
+/// Called when a page load fails with an error.
+typedef PageErrorCallback = void Function(
+    WebViewController controller, String url, WebViewError error);
+
 /* Log severity levels. from CEF include/internal/cef_types.h
   0:default logging (currently info logging)
   1:verbose logging or debug logging
@@ -11,24 +54,36 @@ typedef UrlChangeCb = void Function(String url);
   5:fatal logging
   99:disable logging to file for all messages, and to stderr for messages with severity less than fatal
  */
-typedef LoadStartCb = void Function(WebViewController controller, String url);
-typedef LoadStopCb = void Function(WebViewController controller, String url);
-
-typedef OnConsoleMessage = void Function(
+/// Called when a console message is emitted from the page.
+typedef PageConsoleCallback = void Function(
     int level, String message, String source, int line);
 
-class WebviewEventsListener {
-  TitleChangeCb? onTitleChanged;
-  UrlChangeCb? onUrlChanged;
-  OnConsoleMessage? onConsoleMessage;
-  LoadStartCb? onLoadStart;
-  LoadStopCb? onLoadEnd;
-
-  WebviewEventsListener({
-    this.onTitleChanged,
-    this.onUrlChanged,
+/// Callback for [WebView] events.
+class WebViewEventsListener {
+  const WebViewEventsListener({
     this.onConsoleMessage,
-    this.onLoadStart,
-    this.onLoadEnd,
+    this.onNavigateRequest,
+    this.onPageStarted,
+    this.onPageFinished,
+    this.onProgressUpdated,
+    this.onPageFailed,
   });
+
+  /// Console message from the web page.
+  final PageConsoleCallback? onConsoleMessage;
+
+  /// Intercept a navigation before it starts.
+  final PageNavigationDelegate? onNavigateRequest;
+
+  /// A page has started loading.
+  final PageStartedCallback? onPageStarted;
+
+  /// A page has finished loading.
+  final PageFinishedCallback? onPageFinished;
+
+  /// Page load progress (0.0 – 1.0).
+  final PageProgressCallback? onProgressUpdated;
+
+  /// A page load failed.
+  final PageErrorCallback? onPageFailed;
 }

--- a/lib/src/webview_events_listener.dart
+++ b/lib/src/webview_events_listener.dart
@@ -45,16 +45,26 @@ typedef PageProgressCallback = void Function(
 typedef PageErrorCallback = void Function(
     WebViewController controller, String url, WebViewError error);
 
-/* Log severity levels. from CEF include/internal/cef_types.h
-  0:default logging (currently info logging)
-  1:verbose logging or debug logging
-  2:info logging
-  3:warning logging
-  4:error logging
-  5:fatal logging
-  99:disable logging to file for all messages, and to stderr for messages with severity less than fatal
- */
+/// Called when the CEF render process terminates unexpectedly (crash, OOM,
+/// killed). Use [WebViewController.reload] to restore the page — CEF has
+/// already created a new render process.
+///
+/// [status]: 0 = TS_ABNORMAL_TERMINATION, 1 = TS_PROCESS_WAS_KILLED,
+///           2 = TS_PROCESS_CRASHED, 3 = TS_PROCESS_OOM.
+/// [errorCode]: platform-specific exit/crash code (e.g. Posix signal).
+/// [errorString]: human-readable error description.
+typedef RenderProcessTerminatedCallback = void Function(
+    WebViewController controller, int status, int errorCode, String errorString);
+
 /// Called when a console message is emitted from the page.
+///
+/// [level]: log severity (from CEF include/internal/cef_types.h):
+///   0 = default logging (currently info), 1 = verbose/debug,
+///   2 = info, 3 = warning, 4 = error, 5 = fatal,
+///   99 = disable logging.
+/// [message]: the console message text.
+/// [source]: the source URL or identifier.
+/// [line]: the line number in the source.
 typedef PageConsoleCallback = void Function(
     int level, String message, String source, int line);
 
@@ -67,6 +77,7 @@ class WebViewEventsListener {
     this.onPageFinished,
     this.onProgressUpdated,
     this.onPageFailed,
+    this.onRenderProcessTerminated,
   });
 
   /// Console message from the web page.
@@ -86,4 +97,8 @@ class WebViewEventsListener {
 
   /// A page load failed.
   final PageErrorCallback? onPageFailed;
+
+  /// The CEF render process terminated unexpectedly (crash, OOM, killed).
+  /// Reload the page to restore it — CEF created a new render process.
+  final RenderProcessTerminatedCallback? onRenderProcessTerminated;
 }

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -135,42 +135,55 @@ class WebviewManager extends ValueNotifier<bool> {
         int browserId = call.arguments["browserId"] as int;
         String urlId = call.arguments["urlId"] as String;
 
+        final controller = _webViews[browserId];
+        if (controller == null) return;
+        await controller.ready;
+
         await _injectUserScriptIfNeeds(browserId, _injectUserScripts[browserId]?.retrieveLoadStartInjectScripts() ?? []);
 
-        WebViewController controller =
-        _webViews[browserId] as WebViewController;
-        _webViews[browserId]?.listener?.onPageStarted?.call(controller, urlId);
+        controller.listener?.onPageStarted?.call(controller, urlId);
         return;
       case 'onLoadEnd':
         int browserId = call.arguments["browserId"] as int;
         String urlId = call.arguments["urlId"] as String;
 
+        final controller = _webViews[browserId];
+        if (controller == null) return;
+        await controller.ready;
+
         await _injectUserScriptIfNeeds(browserId, _injectUserScripts[browserId]?.retrieveLoadEndInjectScripts() ?? []);
 
-        WebViewController controller =
-        _webViews[browserId] as WebViewController;
-        _webViews[browserId]?.listener?.onPageFinished?.call(controller, urlId);
+        controller.listener?.onPageFinished?.call(controller, urlId);
         return;
       case 'onBeforeBrowse':
         int browserId = call.arguments['browserId'] as int;
         String url = call.arguments['url'] as String;
-        WebViewController ctrl = _webViews[browserId] as WebViewController;
-        _webViews[browserId]?.listener?.onNavigateRequest?.call(ctrl, url);
+        final controller = _webViews[browserId];
+        if (controller == null) return;
+
+        await controller.ready;
+        controller.listener?.onNavigateRequest?.call(controller, url);
         return;
       case 'onLoadingProgressChange':
         int browserId = call.arguments['browserId'] as int;
         double progress = (call.arguments['progress'] as num).toDouble();
-        WebViewController ctrl2 = _webViews[browserId] as WebViewController;
-        _webViews[browserId]?.listener?.onProgressUpdated?.call(ctrl2, progress);
+        final controller = _webViews[browserId];
+        if (controller == null) return;
+
+        await controller.ready;
+        controller.listener?.onProgressUpdated?.call(controller, progress);
         return;
       case 'onLoadError':
         int browserId = call.arguments['browserId'] as int;
         String errorUrl = call.arguments['url'] as String;
         int errorCode = call.arguments['errorCode'] as int;
         String errorText = call.arguments['errorText'] as String;
-        WebViewController ctrl3 = _webViews[browserId] as WebViewController;
+        final controller = _webViews[browserId];
+        if (controller == null) return;
+
+        await controller.ready;
         final error = WebViewError(errorCode, errorText, {'url': errorUrl});
-        _webViews[browserId]?.listener?.onPageFailed?.call(ctrl3, errorUrl, error);
+        controller.listener?.onPageFailed?.call(controller, errorUrl, error);
         return;
       default:
     }

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -8,6 +8,38 @@ import 'package:webview_cef/src/webview_inject_user_script.dart';
 import 'webview.dart';
 import 'webview_events_listener.dart';
 
+/// CEF process model.
+///
+/// Chromium runs web content in separate, sandboxed processes by default for
+/// security and stability. Choose the model that fits your use case.
+enum ProcessMode {
+  /// Each unique site (eTLD+1) gets its own renderer process. Other processes
+  /// (GPU, network, audio, etc.) remain separate. Strikes a balance between
+  /// isolation and resource usage — typically **5–8 processes** total.
+  ///
+  /// Recommended for production apps that load arbitrary web content.
+  processPerSite(1),
+
+  /// Each browser tab gets its own renderer process. Maximises isolation at the
+  /// cost of higher memory overhead when many tabs are open.
+  processPerTab(2),
+
+  /// Everything — browser, renderer, GPU, network — runs inside a single
+  /// process. Minimal resource footprint (**~1 process**) but no sandbox
+  /// isolation: a renderer crash kills the whole app.
+  ///
+  /// Best for:
+  /// - embedded / kiosk apps that load known, trusted content
+  /// - development and debugging (quick iteration with fewer processes)
+  ///
+  /// Avoid in production if loading untrusted third-party pages.
+  singleProcess(3);
+
+  final int value;
+
+  const ProcessMode(this.value);
+}
+
 class WebviewManager extends ValueNotifier<bool> {
   static final WebviewManager _instance = WebviewManager._internal();
 
@@ -57,14 +89,33 @@ class WebviewManager extends ValueNotifier<bool> {
 
   WebviewManager._internal() : super(false);
 
-  Future<void> initialize({String? userAgent}) async {
+  /// Initialize the CEF engine.
+  ///
+  /// Must be called once before creating any web views. Safe to call multiple
+  /// times — subsequent calls are no-ops.
+  ///
+  /// [userAgent] overrides the default User-Agent string sent with HTTP
+  /// requests.
+  ///
+  /// [processMode] controls the Chromium process model:
+  /// - [ProcessMode.processPerSite] (default) — one renderer per unique site,
+  ///   ~5–8 processes. Best for production with arbitrary web content.
+  /// - [ProcessMode.processPerTab] — one renderer per tab, maximum isolation
+  ///   but higher memory use.
+  /// - [ProcessMode.singleProcess] — everything in one process (~1 process
+  ///   total). Great for debugging, embedded/kiosk apps, or trusted content.
+  ///   No sandbox — avoid with untrusted third-party pages.
+  Future<void> initialize({
+    String? userAgent,
+    ProcessMode processMode = ProcessMode.processPerSite,
+  }) async {
     _creatingCompleter = Completer<void>();
     try {
+      final args = <String, dynamic>{'processMode': processMode.value};
       if (userAgent != null && userAgent.isNotEmpty) {
-        await pluginChannel.invokeMethod('init', userAgent);
-      } else {
-        await pluginChannel.invokeMethod('init');
+        args['userAgent'] = userAgent;
       }
+      await pluginChannel.invokeMethod('init', args);
       pluginChannel.setMethodCallHandler(methodCallhandler);
       // Wait for the platform to complete initialization.
       await Future.delayed(const Duration(milliseconds: 300));

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -198,6 +198,11 @@ class WebviewManager extends ValueNotifier<bool> {
         int browserId = call.arguments["browserId"] as int;
         String urlId = call.arguments["urlId"] as String;
 
+        // Clear any visible tooltip when navigating away from the current
+        // page — CEF does not guarantee an empty OnTooltip() before the
+        // old page is destroyed.
+        _webViews[browserId]?.onToolTip?.call('');
+
         final controller = _webViews[browserId];
         if (controller == null) return;
         await controller.ready;

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -241,6 +241,18 @@ class WebviewManager extends ValueNotifier<bool> {
         await controller.ready;
         controller.listener?.onProgressUpdated?.call(controller, progress);
         return;
+      case 'onRenderProcessTerminated':
+        int browserId = call.arguments['browserId'] as int;
+        int status = call.arguments['status'] as int;
+        int errorCode = call.arguments['errorCode'] as int;
+        String errorString = call.arguments['errorString'] as String;
+        final renderController = _webViews[browserId];
+        if (renderController == null) return;
+
+        await renderController.ready;
+        renderController.listener?.onRenderProcessTerminated
+            ?.call(renderController, status, errorCode, errorString);
+        return;
       case 'onLoadError':
         int browserId = call.arguments['browserId'] as int;
         String errorUrl = call.arguments['url'] as String;

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 import 'package:webview_cef/src/webview_inject_user_script.dart';
 
 import 'webview.dart';
+import 'webview_events_listener.dart';
 
 class WebviewManager extends ValueNotifier<bool> {
   static final WebviewManager _instance = WebviewManager._internal();
@@ -92,20 +93,6 @@ class WebviewManager extends ValueNotifier<bool> {
 
   Future<void> methodCallhandler(MethodCall call) async {
     switch (call.method) {
-      case "urlChanged":
-        int browserId = call.arguments["browserId"] as int;
-        _webViews[browserId]
-            ?.listener
-            ?.onUrlChanged
-            ?.call(call.arguments["url"] as String);
-        return;
-      case "titleChanged":
-        int browserId = call.arguments["browserId"] as int;
-        _webViews[browserId]
-            ?.listener
-            ?.onTitleChanged
-            ?.call(call.arguments["title"] as String);
-        return;
       case "onConsoleMessage":
         int browserId = call.arguments["browserId"] as int;
         _webViews[browserId]?.listener?.onConsoleMessage?.call(
@@ -152,7 +139,7 @@ class WebviewManager extends ValueNotifier<bool> {
 
         WebViewController controller =
         _webViews[browserId] as WebViewController;
-        _webViews[browserId]?.listener?.onLoadStart?.call(controller, urlId);
+        _webViews[browserId]?.listener?.onPageStarted?.call(controller, urlId);
         return;
       case 'onLoadEnd':
         int browserId = call.arguments["browserId"] as int;
@@ -162,7 +149,28 @@ class WebviewManager extends ValueNotifier<bool> {
 
         WebViewController controller =
         _webViews[browserId] as WebViewController;
-        _webViews[browserId]?.listener?.onLoadEnd?.call(controller, urlId);
+        _webViews[browserId]?.listener?.onPageFinished?.call(controller, urlId);
+        return;
+      case 'onBeforeBrowse':
+        int browserId = call.arguments['browserId'] as int;
+        String url = call.arguments['url'] as String;
+        WebViewController ctrl = _webViews[browserId] as WebViewController;
+        _webViews[browserId]?.listener?.onNavigateRequest?.call(ctrl, url);
+        return;
+      case 'onLoadingProgressChange':
+        int browserId = call.arguments['browserId'] as int;
+        double progress = (call.arguments['progress'] as num).toDouble();
+        WebViewController ctrl2 = _webViews[browserId] as WebViewController;
+        _webViews[browserId]?.listener?.onProgressUpdated?.call(ctrl2, progress);
+        return;
+      case 'onLoadError':
+        int browserId = call.arguments['browserId'] as int;
+        String errorUrl = call.arguments['url'] as String;
+        int errorCode = call.arguments['errorCode'] as int;
+        String errorText = call.arguments['errorText'] as String;
+        WebViewController ctrl3 = _webViews[browserId] as WebViewController;
+        final error = WebViewError(errorCode, errorText, {'url': errorUrl});
+        _webViews[browserId]?.listener?.onPageFailed?.call(ctrl3, errorUrl, error);
         return;
       default:
     }

--- a/lib/src/webview_manager.dart
+++ b/lib/src/webview_manager.dart
@@ -105,15 +105,27 @@ class WebviewManager extends ValueNotifier<bool> {
   /// - [ProcessMode.singleProcess] — everything in one process (~1 process
   ///   total). Great for debugging, embedded/kiosk apps, or trusted content.
   ///   No sandbox — avoid with untrusted third-party pages.
+  ///
+  /// [cachePath] overrides the default CEF root cache directory. When omitted,
+  /// each platform derives a unique default to prevent file-lock conflicts
+  /// between multiple CEF-based apps running simultaneously:
+  /// - macOS: `~/Library/Caches/<bundle_id>/cef`
+  /// - Windows: `%LOCALAPPDATA%\<exe_name>\cef`
+  /// - Linux / eLinux: `$XDG_CACHE_HOME/<exe_name>/cef`
+  /// Set this only when your app needs the cache at a specific location.
   Future<void> initialize({
     String? userAgent,
     ProcessMode processMode = ProcessMode.processPerSite,
+    String? cachePath,
   }) async {
     _creatingCompleter = Completer<void>();
     try {
       final args = <String, dynamic>{'processMode': processMode.value};
       if (userAgent != null && userAgent.isNotEmpty) {
         args['userAgent'] = userAgent;
+      }
+      if (cachePath != null && cachePath.isNotEmpty) {
+        args['cachePath'] = cachePath;
       }
       await pluginChannel.invokeMethod('init', args);
       pluginChannel.setMethodCallHandler(methodCallhandler);

--- a/lib/src/webview_tooltip.dart
+++ b/lib/src/webview_tooltip.dart
@@ -78,19 +78,31 @@ class WebviewTooltip {
     });
   }
 
+  void _clearOverlay() {
+    _overlayEntry?.remove();
+    _overlayEntry = null;
+  }
+
   void showToolTip(String text) {
     if (text.isEmpty) {
       if (_eStatus == TooltipStatus.prepare) {
         _timer?.cancel();
       } else {
-        _overlayEntry?.remove();
+        _clearOverlay();
       }
       _eStatus = TooltipStatus.hide;
       return;
-    } else if (_eStatus == TooltipStatus.hide) {
-      _eStatus = TooltipStatus.prepare;
-      _buildOverlayEntry(text);
     }
+
+    // If a tooltip is already visible (or being prepared), tear it down
+    // before showing the new one so rapid text changes don't leave
+    // orphaned overlays stuck on screen.
+    if (_eStatus != TooltipStatus.hide) {
+      _timer?.cancel();
+      _clearOverlay();
+    }
+    _eStatus = TooltipStatus.prepare;
+    _buildOverlayEntry(text);
   }
 }
 

--- a/linux/webview_cef_plugin.cc
+++ b/linux/webview_cef_plugin.cc
@@ -4,7 +4,10 @@
 #include <gtk/gtk.h>
 #include <sys/utsname.h>
 
+#include <climits>
+#include <cstdlib>
 #include <cstring>
+#include <unistd.h>
 #include <unordered_map>
 #include <webview_plugin.h>
 #include "webview_cef_keyevent.h"
@@ -247,6 +250,35 @@ static void webview_cef_plugin_class_init(WebviewCefPluginClass *klass)
 
 static void webview_cef_plugin_init(WebviewCefPlugin *self) {
   self->m_plugin = std::make_shared<webview_cef::WebviewPlugin>();
+
+  // Derive a default CEF cache path from the executable name so that
+  // multiple apps embedding the same CEF framework each get their own
+  // isolated cache directory.  If the Dart layer provides a cachePath
+  // via initialize(), it will override this default in startCEF().
+  char exePath[PATH_MAX] = {};
+  ssize_t len = readlink("/proc/self/exe", exePath, sizeof(exePath) - 1);
+  std::string exeName = "webview_cef";  // fallback
+  if (len > 0) {
+    exePath[len] = '\0';
+    std::string fullPath(exePath);
+    size_t lastSlash = fullPath.find_last_of('/');
+    if (lastSlash != std::string::npos) {
+      exeName = fullPath.substr(lastSlash + 1);
+    }
+  }
+  const char* xdgCache = getenv("XDG_CACHE_HOME");
+  std::string cacheDir;
+  if (xdgCache && xdgCache[0]) {
+    cacheDir = xdgCache;
+  } else {
+    const char* home = getenv("HOME");
+    if (home && home[0]) {
+      cacheDir = std::string(home) + "/.cache";
+    }
+  }
+  if (!cacheDir.empty()) {
+    webview_cef::setCefCachePath(cacheDir + "/" + exeName + "/cef");
+  }
 }
 
 static void method_call_cb(FlMethodChannel *channel, FlMethodCall *method_call,

--- a/macos/Classes/CefWrapper.mm
+++ b/macos/Classes/CefWrapper.mm
@@ -230,7 +230,7 @@ private:
         return false;
     }
 
-    CefKeyEvent keyEvent;
+    CefKeyEvent keyEvent = {};
     
     NSString* s = [event characters];
     

--- a/macos/Classes/CefWrapper.mm
+++ b/macos/Classes/CefWrapper.mm
@@ -206,6 +206,12 @@ private:
 // versus navigation/control keys and shortcuts (which CEF handles as raw key
 // events). Returning YES means "let the IME have it"; NO means "send to CEF".
 + (BOOL)isImeRoutableKeyEvent:(NSEvent*)event {
+    // NSEventTypeFlagsChanged events (modifier-key presses like Ctrl, Opt, Shift,
+    // Cmd, CapsLock, Fn) carry no characters. |charactersIgnoringModifiers| is
+    // only valid for KeyDown / KeyUp and throws on macOS 26+ for FlagsChanged.
+    if ([event type] == NSEventTypeFlagsChanged) {
+        return NO;
+    }
     NSEventModifierFlags flags = [event modifierFlags];
     // Shortcuts / control sequences (⌘/⌃ chords) go straight to CEF.
     if (flags & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) {
@@ -252,31 +258,63 @@ private:
     }
 
     CefKeyEvent keyEvent = {};
-    
-    NSString* s = [event characters];
-    
-    if ([s length] != 0){
-        keyEvent.character = [s characterAtIndex:0];
+
+    // |characters| and |charactersIgnoringModifiers| are only valid for
+    // NSEventTypeKeyDown and NSEventTypeKeyUp. On macOS 26+, calling them on
+    // an NSEventTypeFlagsChanged event throws an ObjC exception. Extract
+    // characters first for key-down/up events, then let the FlagsChanged
+    // branch below zero them out.
+    if ([event type] != NSEventTypeFlagsChanged) {
+        NSString* s = [event characters];
+        if ([s length] != 0){
+            keyEvent.character = [s characterAtIndex:0];
+        }
+
+        s = [event charactersIgnoringModifiers];
+        if ([s length] > 0){
+            keyEvent.unmodified_character = [s characterAtIndex:0];
+        }
     }
 
-    s = [event charactersIgnoringModifiers];
-    if ([s length] > 0){
-        keyEvent.unmodified_character = [s characterAtIndex:0];
-    }
-    
-    if ([event type] == NSEventTypeFlagsChanged){
-        keyEvent.character = 0;
-        keyEvent.unmodified_character = 0;
-    }
-        
     keyEvent.native_key_code = [event keyCode];
-    
+
     keyEvent.modifiers = [CefWrapper getModifiersForEvent:event];
 
-//    if(keyEvent.native_key_code == 51){
-//        keyEvent.character = 0;
-//        keyEvent.unmodified_character = 0;
-//    }
+    // FlagsChanged (modifier keys like Cmd/Shift/Option/Ctrl) does not
+    // distinguish press vs release — determine it from the new modifier state.
+    // Must handle this BEFORE the KeyDown/KeyUp check so modifier state changes
+    // are consumed and never leak through to Flutter's HardwareKeyboard.
+    if ([event type] == NSEventTypeFlagsChanged) {
+        bool isPress = false;
+        switch ([event keyCode]) {
+            case 54: // Command Right
+            case 55: // Command Left
+                isPress = ([event modifierFlags] & NSEventModifierFlagCommand) != 0;
+                break;
+            case 56: // Shift Left
+            case 60: // Shift Right
+                isPress = ([event modifierFlags] & NSEventModifierFlagShift) != 0;
+                break;
+            case 59: // Control Left
+            case 62: // Control Right
+                isPress = ([event modifierFlags] & NSEventModifierFlagControl) != 0;
+                break;
+            case 58: // Option Left
+            case 61: // Option Right
+                isPress = ([event modifierFlags] & NSEventModifierFlagOption) != 0;
+                break;
+            case 63: // Function
+                isPress = ([event modifierFlags] & NSEventModifierFlagFunction) != 0;
+                break;
+            default:
+                isPress = true;
+                break;
+        }
+        keyEvent.type = isPress ? KEYEVENT_RAWKEYDOWN : KEYEVENT_KEYUP;
+        currentPlugin->_plugin->sendKeyEvent(keyEvent);
+        return true;
+    }
+
     if([event type] == NSEventTypeKeyDown){
         keyEvent.type = KEYEVENT_RAWKEYDOWN;
         currentPlugin->_plugin->sendKeyEvent(keyEvent);
@@ -450,14 +488,7 @@ private:
     if(isCefMessageLoop == NO){
         _timer = [NSTimer timerWithTimeInterval:0.016f target:self selector:@selector(doMessageLoopWork) userInfo:nil repeats:YES];
         [[NSRunLoop mainRunLoop] addTimer: _timer forMode:NSRunLoopCommonModes];
-        [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown handler:^NSEvent * _Nullable(NSEvent * _Nonnull event) {
-            if([CefWrapper processKeyboardEvent:event]){
-                return nil;
-            }
-            return event;
-        }];
-            
-        [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp handler:^NSEvent * _Nullable(NSEvent * _Nonnull event) {
+        [NSEvent addLocalMonitorForEventsMatchingMask:(NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged) handler:^NSEvent * _Nullable(NSEvent * _Nonnull event) {
             if([CefWrapper processKeyboardEvent:event]){
                 return nil;
             }

--- a/macos/Classes/CefWrapper.mm
+++ b/macos/Classes/CefWrapper.mm
@@ -509,4 +509,37 @@ private:
    }
     webview_value_unref(encodeArgs);
 }
+
+- (void)dealloc {
+    // Destroy the plugin first — ~WebviewPlugin calls CloseAllBrowsers(true)
+    // to close every live browser before we tear down CEF itself.
+    _plugin = nullptr;
+
+    // NSMapTable is weak-to-weak, so this wrapper has already been
+    // auto-removed by the runtime by the time dealloc executes.
+    // If no wrappers remain, stop the global CEF machinery.
+    if ([[webviewPlugins objectEnumerator] allObjects].count == 0) {
+        // Stop the CVDisplayLink (vsync-driven frame clock for GPU path).
+        if (_displayLinkActive && _displayLink) {
+            CVDisplayLinkStop(_displayLink);
+            _displayLinkActive = NO;
+        }
+        if (_displayLink) {
+            CVDisplayLinkRelease(_displayLink);
+            _displayLink = NULL;
+        }
+
+        // Stop the message-pump timer (software path fallback).
+        if (_timer) {
+            [_timer invalidate];
+            _timer = nil;
+        }
+
+        // Shutdown CEF — terminates the browser process and all subprocesses
+        // (renderer, GPU, network, etc.).
+        webview_cef::stopCEF();
+        isCefMessageLoop = NO;
+    }
+}
+
 @end

--- a/macos/Classes/CefWrapper.mm
+++ b/macos/Classes/CefWrapper.mm
@@ -16,6 +16,7 @@
 #import "../../common/webview_plugin.h"
 #import "../../common/webview_value.h"
 #import <CoreVideo/CoreVideo.h>
+#import <objc/runtime.h>
 #include <thread>
 
 static NSTimer* _timer;
@@ -29,6 +30,26 @@ NSMapTable* webviewPlugins = [NSMapTable weakToWeakObjectsMapTable];
 // Fires on a high-priority background thread once per display refresh. Hop to
 // the main thread (the CEF UI thread under external_message_pump) to deliver the
 // frame produced by the previous tick and request the next one.
+// CEF on macOS with external_message_pump may call -[NSApplication isHandlingSendEvent]
+// when routing events to a native popup window (e.g. DevTools). That selector belongs
+// to NSWindow, not NSApplication, so it would crash with an unrecognized-selector
+// exception. Provide a no-op implementation on NSApplication as a workaround.
+@interface NSApplication (CEFWorkaround)
+- (BOOL)isHandlingSendEvent;
+- (void)setHandlingSendEvent:(BOOL)handlingSendEvent;
+@end
+
+@implementation NSApplication (CEFWorkaround)
+- (BOOL)isHandlingSendEvent {
+    NSNumber *value = objc_getAssociatedObject(self, @selector(setHandlingSendEvent:));
+    return value ? [value boolValue] : NO;
+}
+- (void)setHandlingSendEvent:(BOOL)handlingSendEvent {
+    objc_setAssociatedObject(self, @selector(setHandlingSendEvent:),
+                             @(handlingSendEvent), OBJC_ASSOCIATION_RETAIN);
+}
+@end
+
 static CVReturn WebviewDisplayLinkCallback(CVDisplayLinkRef displayLink,
                                            const CVTimeStamp* now,
                                            const CVTimeStamp* outputTime,

--- a/macos/Classes/CefWrapper.mm
+++ b/macos/Classes/CefWrapper.mm
@@ -445,6 +445,7 @@ private:
             // (see the example Runner's "Embed CEF Helpers" build phase).
             NSBundle* mainBundle = [NSBundle mainBundle];
             NSString* bundlePath = [mainBundle bundlePath];
+            NSString* bundleId = [mainBundle bundleIdentifier];
             NSString* exeName = [mainBundle objectForInfoDictionaryKey:@"CFBundleExecutable"];
             NSString* helperName = [exeName stringByAppendingString:@" Helper"];
             NSString* frameworksDir = [bundlePath stringByAppendingPathComponent:@"Contents/Frameworks"];
@@ -457,6 +458,21 @@ private:
                 webview_cef::setMacCEFPaths(std::string([subprocessPath UTF8String]),
                                             std::string([frameworkDir UTF8String]),
                                             std::string([bundlePath UTF8String]));
+            }
+            // Assign each app instance its own CEF cache directory so that
+            // multiple CEF-based apps can run concurrently without locking
+            // each other out of the default shared cache. Uses the macOS
+            // ~/Library/Caches/<bundle_identifier>/cef convention.
+            if (bundleId) {
+                NSString* cachesDir = [NSSearchPathForDirectoriesInDomains(
+                    NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+                if (cachesDir) {
+                    NSString* cachePath = [[cachesDir
+                        stringByAppendingPathComponent:bundleId]
+                        stringByAppendingPathComponent:@"cef"];
+                    webview_cef::setCefCachePath(
+                        std::string([cachePath UTF8String]));
+                }
             }
             webview_cef::initCEFProcesses();
             isCefProcessInit = YES;

--- a/macos/Classes/CefWrapper.mm
+++ b/macos/Classes/CefWrapper.mm
@@ -257,6 +257,20 @@ private:
         return false;
     }
 
+    // Intercept Cmd+V for paste in OSR mode. CEF off-screen rendering
+    // bypasses AppKit's interpretKeyEvents: so Cmd+V never triggers the
+    // system pasteboard read. Grab the clipboard text here and inject it
+    // via JavaScript into the focused element.
+    if ([event type] == NSEventTypeKeyDown &&
+        [event keyCode] == 9 &&  // V key
+        ([event modifierFlags] & NSEventModifierFlagCommand)) {
+        NSString *text = [[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString];
+        if (text.length > 0) {
+            currentPlugin->_plugin->pasteText([text UTF8String]);
+        }
+        return YES;
+    }
+
     CefKeyEvent keyEvent = {};
 
     // |characters| and |charactersIgnoringModifiers| are only valid for

--- a/macos/embed_cef_helpers.rb
+++ b/macos/embed_cef_helpers.rb
@@ -18,7 +18,9 @@
 # Without this hook the plugin still works, but falls back to single-process.
 module WebviewCEF
   PHASE_NAME = 'Embed CEF Helpers'.freeze
-  SCRIPT = 'bash "${SRCROOT}/Flutter/ephemeral/.symlinks/plugins/webview_cef/macos/scripts/embed_cef_helpers.sh"'.freeze
+  SCRIPT = 'echo "$PRODUCT_NAME.app" > "${SRCROOT}/Flutter/ephemeral/.app_filename"' + "\n" +
+         '"$FLUTTER_ROOT"/packages/flutter_tools/bin/macos_assemble.sh embed' + "\n" +
+         'bash "${SRCROOT}/Flutter/ephemeral/.symlinks/plugins/webview_cef/macos/scripts/embed_cef_helpers.sh"'.freeze
 
   def self.install_helper_phase(installer)
     installer.aggregate_targets.each do |aggregate|

--- a/macos/scripts/download_cef.sh
+++ b/macos/scripts/download_cef.sh
@@ -6,10 +6,10 @@
 # (see third/download.cmake): nothing under macos/third/cef is tracked in git;
 # it is fetched/built on demand.
 #
-# It performs three steps that previously had to be done by hand (see README):
-#   1. download + extract the CEF distribution (provides include/ headers)
-#   2. lay the framework out as a versioned macOS bundle (Versions/A + symlinks)
-#   3. build libcef_dll_wrapper.a from the distribution's sources
+# By default this script produces a universal (arm64 + x86_64) CEF:
+# both architecture packages are downloaded, built separately, and merged with
+# lipo. Set CEF_UNIVERSAL=0 to fall back to a single host-architecture build
+# (emergency escape hatch for low-disk / poor-network situations).
 #
 # The CEF version is read from third/download.cmake so there is a single source
 # of truth shared with Windows/Linux. Re-running is cheap: if the destination is
@@ -34,15 +34,36 @@ err() { echo "error: $*" >&2; exit 1; }
 CEF_VERSION="$(sed -n 's/^[[:space:]]*set(CEF_VERSION[[:space:]]*"\(.*\)").*/\1/p' "${DOWNLOAD_CMAKE}" | head -1)"
 [ -n "${CEF_VERSION}" ] || err "could not parse CEF_VERSION from ${DOWNLOAD_CMAKE}"
 
-case "$(uname -m)" in
-  arm64)  CEF_ARCH="macosarm64"; PROJECT_ARCH="arm64" ;;
-  x86_64) CEF_ARCH="macosx64";   PROJECT_ARCH="x86_64" ;;
-  *)      err "unsupported arch: $(uname -m)" ;;
-esac
+# --- helpers ------------------------------------------------------------------
+cef_arch_for() {
+  case "$1" in
+    arm64)  echo "macosarm64" ;;
+    x86_64) echo "macosx64" ;;
+  esac
+}
 
-PKG="cef_binary_${CEF_VERSION}_${CEF_ARCH}"
+# --- determine target architectures -------------------------------------------
+# Default: universal (arm64 + x86_64). Set CEF_UNIVERSAL=0 for single-arch
+# fallback (emergency escape hatch).
+if [ "${CEF_UNIVERSAL:-}" = "0" ]; then
+  case "$(uname -m)" in
+    arm64)  ARCHES=("arm64") ;;
+    x86_64) ARCHES=("x86_64") ;;
+    *)      err "unsupported arch: $(uname -m)" ;;
+  esac
+else
+  ARCHES=("arm64" "x86_64")
+fi
+
+# Build human-readable arch label for the stamp.
+if [ ${#ARCHES[@]} -gt 1 ]; then
+  ARCH_LABEL="arm64,x86_64"
+else
+  ARCH_LABEL="$(cef_arch_for "${ARCHES[0]}")"
+fi
+
 STAMP="${DEST}/version.txt"
-WANT="${CEF_VERSION}_${CEF_ARCH}_${BUILD_TYPE}"
+WANT="${CEF_VERSION}_${ARCH_LABEL}_${BUILD_TYPE}"
 
 # --- compute source-content hash for the helper's dependencies ----------------
 # When any source file compiled into cef_helper changes, the hash embedded in
@@ -68,16 +89,38 @@ HELPER_SOURCES=(
 SOURCE_HASH=$(cat "${HELPER_SOURCES[@]}" 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
 WANT="${WANT}_${SOURCE_HASH}"
 
-# --- skip if already prepared for this exact version/arch/type ---------------
-if [ -f "${STAMP}" ] && [ "$(cat "${STAMP}" 2>/dev/null)" = "${WANT}" ] \
-   && [ -f "${DEST}/libcef_dll_wrapper.a" ] \
-   && [ -f "${DEST}/cef_helper" ] \
-   && [ -e "${DEST}/Chromium Embedded Framework.framework/Resources/Info.plist" ] \
-   && [ -f "${DEST}/include/cef_version.h" ]; then
-  echo "CEF ${WANT} already prepared in ${DEST} — nothing to do."
+# --- helpers ------------------------------------------------------------------
+is_fat() {
+  lipo -info "$1" 2>/dev/null | grep -q 'Architectures in the fat file'
+}
+
+# --- skip if already prepared for this exact version / arch / type -----------
+cache_valid() {
+  [ -f "${STAMP}" ] || return 1
+  [ "$(cat "${STAMP}" 2>/dev/null)" = "${WANT}" ] || return 1
+  [ -f "${DEST}/include/cef_version.h" ] || return 1
+
+  if [ ${#ARCHES[@]} -gt 1 ]; then
+    # Universal: additionally verify key files are actually fat.
+    is_fat "${DEST}/libcef_dll_wrapper.a" || return 1
+    is_fat "${DEST}/cef_helper" || return 1
+    is_fat "${DEST}/Chromium Embedded Framework.framework/Versions/A/Chromium Embedded Framework" || return 1
+  else
+    [ -f "${DEST}/libcef_dll_wrapper.a" ] || return 1
+    [ -f "${DEST}/cef_helper" ] || return 1
+    [ -e "${DEST}/Chromium Embedded Framework.framework/Resources/Info.plist" ] || return 1
+  fi
+  return 0
+}
+
+if cache_valid; then
+  echo "==> CEF ${CEF_VERSION} (${ARCH_LABEL}, ${BUILD_TYPE}) already prepared — nothing to do."
   exit 0
 fi
 
+echo "==> Preparing CEF ${CEF_VERSION} (${ARCH_LABEL}, ${BUILD_TYPE})"
+
+# --- tool checks -------------------------------------------------------------
 command -v cmake >/dev/null || err "cmake not found (brew install cmake) — needed to build libcef_dll_wrapper"
 if command -v ninja >/dev/null && ninja --version >/dev/null 2>&1; then
   GENERATOR="Ninja"; BUILD_TOOL=(ninja libcef_dll_wrapper)
@@ -85,92 +128,222 @@ else
   GENERATOR="Unix Makefiles"; BUILD_TOOL=(make -j"$(sysctl -n hw.ncpu)" libcef_dll_wrapper)
 fi
 
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/cef_dl.XXXXXX")"
-trap 'rm -rf "${WORK}"' EXIT
-TARBALL="${WORK}/${PKG}.tar.bz2"
-# CDN requires '+' percent-encoded as %2B.
-URL="${CDN}/$(printf '%s' "${PKG}.tar.bz2" | sed 's/+/%2B/g')"
+if [ ${#ARCHES[@]} -gt 1 ]; then
+  command -v lipo >/dev/null || err "lipo not found — required for universal binary merge"
+fi
 
-echo "==> Downloading ${PKG}.tar.bz2 (from ${CDN})"
-# curl --retry does NOT cover error 18 (partial transfer) by default,
-# so we implement a bash-level retry loop with resume (-C -) support.
-# The server supports Range requests, so each attempt appends to the partial
-# file. This is critical when the CDN connection is unstable: even if every
-# attempt delivers only a few MB before being cut off, enough attempts will
-# eventually complete the download.
-MAX_ATTEMPTS=3
-RETRY_DELAY_SEC=5
-attempt=1
-while [ $attempt -le $MAX_ATTEMPTS ]; do
-  if [ -f "${TARBALL}" ]; then
-    downloaded=$(stat -f%z "${TARBALL}" 2>/dev/null || echo 0)
-    echo "  [${attempt}/${MAX_ATTEMPTS}] Resuming from ${downloaded} bytes ($(( downloaded * 100 / 280729682 ))%)"
-  else
-    echo "  [${attempt}/${MAX_ATTEMPTS}] Starting download..."
-  fi
-  if curl -L --fail --connect-timeout 30 --max-time 1800 \
-       --retry-all-errors --retry 3 --retry-delay 5 \
-       -C - -o "${TARBALL}" "${URL}"; then
-    echo "==> Download complete"
-    break
-  fi
-  rc=$?
-  echo "  curl exited with code ${rc}"
-  if [ $attempt -ge $MAX_ATTEMPTS ]; then
-    err "Download failed after ${MAX_ATTEMPTS} attempts"
-  fi
-  sleep $RETRY_DELAY_SEC
-  attempt=$((attempt + 1))
+# --- temporary build directories ----------------------------------------------
+TEMP_DIRS=()
+for arch in "${ARCHES[@]}"; do
+  TEMP_DIR="${DEST}/_build_${arch}"
+  rm -rf "${TEMP_DIR}"
+  mkdir -p "${TEMP_DIR}"
+  TEMP_DIRS+=("${TEMP_DIR}")
 done
 
-echo "==> Extracting"
-if ! tar -xjf "${TARBALL}" -C "${WORK}"; then
-  err "Extraction failed — the downloaded archive may be corrupted. Try removing any cached partial download and re-run."
-fi
-SRC="${WORK}/${PKG}"
-[ -d "${SRC}" ] || err "extracted dir ${SRC} not found"
+cleanup() {
+  for d in "${TEMP_DIRS[@]}"; do
+    rm -rf "${d}"
+  done
+}
+trap cleanup EXIT
 
-echo "==> Building libcef_dll_wrapper (${BUILD_TYPE}, ${PROJECT_ARCH})"
-cmake -S "${SRC}" -B "${SRC}/build" -G "${GENERATOR}" \
-  -DPROJECT_ARCH="${PROJECT_ARCH}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 >/dev/null
-( cd "${SRC}/build" && "${BUILD_TOOL[@]}" >/dev/null )
-WRAPPER="${SRC}/build/libcef_dll_wrapper/libcef_dll_wrapper.a"
-[ -f "${WRAPPER}" ] || err "libcef_dll_wrapper.a was not produced"
+# --- download_and_build(arch, cef_arch, work_dir) ----------------------------
+# Downloads the CEF package for a single architecture, extracts it, builds
+# libcef_dll_wrapper.a and cef_helper. The helper must be built per-architecture
+# (arm64 helper links arm64 wrapper, x86_64 helper links x86_64 wrapper);
+# lipo merges them afterwards.
+download_and_build() {
+  local arch=$1
+  local cef_arch=$2
+  local work=$3
 
+  local pkg="cef_binary_${CEF_VERSION}_${cef_arch}"
+  local tarball="${work}/${pkg}.tar.bz2"
+
+  # If a local tarball exists under cef_tar/ (committed to the repo for
+  # offline builds), use it directly — saves ~10 minutes of slow CDN download.
+  local local_tar="${REPO_ROOT}/cef_tar/${pkg}.tar.bz2"
+  if [ -f "${local_tar}" ]; then
+    echo "==> Using local ${pkg}.tar.bz2 (${arch}) from cef_tar/"
+    cp "${local_tar}" "${tarball}"
+  else
+    # CDN requires '+' percent-encoded as %2B.
+    local url="${CDN}/$(printf '%s' "${pkg}.tar.bz2" | sed 's/+/%2B/g')"
+
+    echo "==> Downloading ${pkg}.tar.bz2 (${arch})"
+    # curl --retry does NOT cover error 18 (partial transfer) by default,
+    # so we implement a bash-level retry loop with resume (-C -) support.
+    # The server supports Range requests, so each attempt appends to the partial
+    # file. This is critical when the CDN connection is unstable: even if every
+    # attempt delivers only a few MB before being cut off, enough attempts will
+    # eventually complete the download.
+    local max_attempts=3
+    local retry_delay_sec=5
+    local attempt=1
+    while [ $attempt -le $max_attempts ]; do
+      if [ -f "${tarball}" ]; then
+        local downloaded
+        downloaded=$(stat -f%z "${tarball}" 2>/dev/null || echo 0)
+        echo "  [${attempt}/${max_attempts}] Resuming from ${downloaded} bytes"
+      else
+        echo "  [${attempt}/${max_attempts}] Starting download..."
+      fi
+      if curl -L --fail --connect-timeout 30 --max-time 1800 \
+           --retry-all-errors --retry 3 --retry-delay 5 \
+           -C - -o "${tarball}" "${url}"; then
+        echo "==> Download complete (${arch})"
+        break
+      fi
+      local rc=$?
+      echo "  curl exited with code ${rc}"
+      if [ $attempt -ge $max_attempts ]; then
+        err "Download failed after ${max_attempts} attempts (${arch})"
+      fi
+      sleep $retry_delay_sec
+      attempt=$((attempt + 1))
+    done
+  fi
+
+  echo "==> Extracting (${arch})"
+  if ! tar -xjf "${tarball}" -C "${work}"; then
+    err "Extraction failed (${arch}) — the downloaded archive may be corrupted. Try removing any cached partial download and re-run."
+  fi
+  local src="${work}/${pkg}"
+  [ -d "${src}" ] || err "extracted dir ${src} not found (${arch})"
+
+  echo "==> Building libcef_dll_wrapper (${BUILD_TYPE}, ${arch})"
+  cmake -S "${src}" -B "${src}/build" -G "${GENERATOR}" \
+    -DPROJECT_ARCH="${arch}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 >/dev/null 2>&1
+  echo "    cmake configured (${arch})"
+  ( cd "${src}/build" && "${BUILD_TOOL[@]}" >/dev/null 2>&1 )
+  echo "    libcef_dll_wrapper built (${arch})"
+  local wrapper="${src}/build/libcef_dll_wrapper/libcef_dll_wrapper.a"
+  [ -f "${wrapper}" ] || err "libcef_dll_wrapper.a was not produced (${arch})"
+
+  echo "==> Building cef_helper (${arch})"
+  clang++ -std=c++20 -stdlib=libc++ -mmacosx-version-min=12.0 -w \
+    -arch "${arch}" \
+    -I "${src}" -I "${REPO_ROOT}/common" \
+    "${MACOS_DIR}/helper/cef_helper_main.mm" \
+    "${wrapper}" \
+    -framework Foundation -framework AppKit \
+    -Wl,-ObjC \
+    -o "${work}/cef_helper"
+  [ -f "${work}/cef_helper" ] || err "cef_helper was not produced (${arch})"
+}
+
+# --- execute per-architecture build (sequential) -----------------------------
+  TOTAL=${#ARCHES[@]}
+  for i in "${!ARCHES[@]}"; do
+    arch="${ARCHES[$i]}"
+    cef_arch="$(cef_arch_for "$arch")"
+    step=$((i + 1))
+    echo "==> [${step}/${TOTAL}] Building ${arch} (${cef_arch})"
+    work="${TEMP_DIRS[$i]}"
+    download_and_build "${arch}" "${cef_arch}" "${work}"
+  done
+
+# --- prepare destination -----------------------------------------------------
 echo "==> Installing into ${DEST}"
 rm -rf "${DEST}/include" "${DEST}/Chromium Embedded Framework.framework" \
-       "${DEST}/libcef_dll_wrapper.a" "${STAMP}"
+       "${DEST}/libcef_dll_wrapper.a" "${DEST}/cef_helper" "${STAMP}"
 mkdir -p "${DEST}"
-cp -R "${SRC}/include" "${DEST}/include"
-cp "${WRAPPER}" "${DEST}/libcef_dll_wrapper.a"
 
-# Lay the framework out as a versioned macOS bundle (Xcode embed/sign requires
-# Versions/Current/Resources/Info.plist; CEF ships a flat bundle).
-FW_SRC="${SRC}/Release/Chromium Embedded Framework.framework"
-FW_DST="${DEST}/Chromium Embedded Framework.framework"
-mkdir -p "${FW_DST}/Versions/A"
-cp -R "${FW_SRC}/Chromium Embedded Framework" "${FW_DST}/Versions/A/"
-cp -R "${FW_SRC}/Libraries" "${FW_DST}/Versions/A/"
-cp -R "${FW_SRC}/Resources" "${FW_DST}/Versions/A/"
-ln -sfn A "${FW_DST}/Versions/Current"
-ln -sfn "Versions/Current/Chromium Embedded Framework" "${FW_DST}/Chromium Embedded Framework"
-ln -sfn Versions/Current/Libraries "${FW_DST}/Libraries"
-ln -sfn Versions/Current/Resources "${FW_DST}/Resources"
+# Convenience: extract the first (or only) arch's source directory.
+FIRST_ARCH="${ARCHES[0]}"
+FIRST_CEF_ARCH="$(cef_arch_for "$FIRST_ARCH")"
+FIRST_SRC="${TEMP_DIRS[0]}/cef_binary_${CEF_VERSION}_${FIRST_CEF_ARCH}"
 
-# Build the standalone CEF helper executable used by the multi-process helper
-# bundles (embed_cef_helpers.sh clones this into the 5 named .app bundles).
-# It links the wrapper statically; the framework is dlopen'd at runtime
-# (LoadInHelper), so it does not link the framework here.
-echo "==> Building CEF helper executable"
-clang++ -std=c++20 -stdlib=libc++ -mmacosx-version-min=12.0 -w \
-  -I "${DEST}" -I "${REPO_ROOT}/common" \
-  "${MACOS_DIR}/helper/cef_helper_main.mm" \
-  "${DEST}/libcef_dll_wrapper.a" \
-  -framework Foundation -framework AppKit \
-  -Wl,-ObjC \
-  -o "${DEST}/cef_helper"
-[ -f "${DEST}/cef_helper" ] || err "cef_helper was not produced"
+# Headers are identical across architectures — copy from the first package.
+cp -R "${FIRST_SRC}/include" "${DEST}/include"
+echo "  include headers installed"
 
-echo "${WANT}" > "${STAMP}"
-echo "==> Done: CEF ${CEF_VERSION} (${CEF_ARCH}, wrapper ${BUILD_TYPE}) ready in ${DEST}"
+if [ ${#ARCHES[@]} -gt 1 ]; then
+  # =========================================================================
+  # Universal path: lipo-merge everything.
+  # =========================================================================
+
+  SECOND_ARCH="${ARCHES[1]}"
+  SECOND_CEF_ARCH="$(cef_arch_for "$SECOND_ARCH")"
+  SECOND_SRC="${TEMP_DIRS[1]}/cef_binary_${CEF_VERSION}_${SECOND_CEF_ARCH}"
+
+  # --- lipo libcef_dll_wrapper.a ------------------------------------------
+  echo "==> Merging libcef_dll_wrapper.a (arm64 + x86_64 → universal)"
+  ARM64_WRAPPER=$(find "${TEMP_DIRS[0]}" -name "libcef_dll_wrapper.a" -path "*/libcef_dll_wrapper/*" | head -1)
+  X86_64_WRAPPER=$(find "${TEMP_DIRS[1]}" -name "libcef_dll_wrapper.a" -path "*/libcef_dll_wrapper/*" | head -1)
+  lipo -create "${ARM64_WRAPPER}" "${X86_64_WRAPPER}" \
+    -output "${DEST}/libcef_dll_wrapper.a"
+
+  # --- install & lipo Chromium Embedded Framework.framework ---------------
+  echo "==> Merging Chromium Embedded Framework.framework"
+  FW_SRC_ARM64="${FIRST_SRC}/Release/Chromium Embedded Framework.framework"
+  FW_SRC_X86_64="${SECOND_SRC}/Release/Chromium Embedded Framework.framework"
+
+  # Lay the framework out as a versioned macOS bundle using arm64 as the base
+  # (Xcode embed/sign requires Versions/Current/Resources/Info.plist; CEF
+  # ships a flat bundle).
+  FW_DST="${DEST}/Chromium Embedded Framework.framework"
+  mkdir -p "${FW_DST}/Versions/A"
+  cp -R "${FW_SRC_ARM64}/Chromium Embedded Framework" "${FW_DST}/Versions/A/"
+  cp -R "${FW_SRC_ARM64}/Libraries" "${FW_DST}/Versions/A/"
+  cp -R "${FW_SRC_ARM64}/Resources" "${FW_DST}/Versions/A/"
+  ln -sfn A "${FW_DST}/Versions/Current"
+  ln -sfn "Versions/Current/Chromium Embedded Framework" "${FW_DST}/Chromium Embedded Framework"
+  ln -sfn Versions/Current/Libraries "${FW_DST}/Libraries"
+  ln -sfn Versions/Current/Resources "${FW_DST}/Resources"
+
+  # Scan every Mach-O file in the framework and lipo-merge with its x86_64
+  # counterpart. This auto-adapts to CEF upgrades (new/removed dylibs).
+  echo "  (scanning framework for Mach-O files...)"
+  merged_count=0
+  while IFS= read -r f; do
+    if file "$f" 2>/dev/null | grep -q "Mach-O"; then
+      rel="${f#$FW_DST}"
+      # FW_DST uses a versioned layout (Versions/A/...), but the x86_64
+      # source is a flat bundle. Strip the Versions/A/ prefix to map.
+      flat_rel="${rel#/Versions/A/}"
+      x86_file="${FW_SRC_X86_64}/${flat_rel}"
+
+      if [ -f "$x86_file" ]; then
+        echo "    lipo: ${rel}"
+        lipo -create "$f" "$x86_file" -output "$f.tmp" || err "lipo failed for ${rel}"
+        mv "$f.tmp" "$f"
+        merged_count=$((merged_count + 1))
+      fi
+    fi
+  done < <(find "${FW_DST}" -type f)
+  echo "  ${merged_count} Mach-O file(s) merged"
+
+  # --- lipo cef_helper ----------------------------------------------------
+  echo "==> Merging cef_helper (arm64 + x86_64 → universal)"
+  lipo -create "${TEMP_DIRS[0]}/cef_helper" "${TEMP_DIRS[1]}/cef_helper" \
+    -output "${DEST}/cef_helper"
+  [ -f "${DEST}/cef_helper" ] || err "cef_helper was not produced"
+
+else
+  # =========================================================================
+  # Single-arch fallback path (CEF_UNIVERSAL=0): copy directly, no lipo.
+  # =========================================================================
+
+  cp "${FIRST_SRC}/build/libcef_dll_wrapper/libcef_dll_wrapper.a" "${DEST}/libcef_dll_wrapper.a"
+
+  # Lay the framework out as a versioned macOS bundle.
+  FW_SRC="${FIRST_SRC}/Release/Chromium Embedded Framework.framework"
+  FW_DST="${DEST}/Chromium Embedded Framework.framework"
+  mkdir -p "${FW_DST}/Versions/A"
+  cp -R "${FW_SRC}/Chromium Embedded Framework" "${FW_DST}/Versions/A/"
+  cp -R "${FW_SRC}/Libraries" "${FW_DST}/Versions/A/"
+  cp -R "${FW_SRC}/Resources" "${FW_DST}/Versions/A/"
+  ln -sfn A "${FW_DST}/Versions/Current"
+  ln -sfn "Versions/Current/Chromium Embedded Framework" "${FW_DST}/Chromium Embedded Framework"
+  ln -sfn Versions/Current/Libraries "${FW_DST}/Libraries"
+  ln -sfn Versions/Current/Resources "${FW_DST}/Resources"
+
+  cp "${TEMP_DIRS[0]}/cef_helper" "${DEST}/cef_helper"
+fi
+
+# --- write stamp (atomic: .tmp → rename) ------------------------------------
+echo "${WANT}" > "${STAMP}.tmp" && mv "${STAMP}.tmp" "${STAMP}"
+echo "==> Done: CEF ${CEF_VERSION} (${ARCH_LABEL}, wrapper ${BUILD_TYPE}) ready in ${DEST}"

--- a/macos/scripts/download_cef.sh
+++ b/macos/scripts/download_cef.sh
@@ -44,6 +44,30 @@ PKG="cef_binary_${CEF_VERSION}_${CEF_ARCH}"
 STAMP="${DEST}/version.txt"
 WANT="${CEF_VERSION}_${CEF_ARCH}_${BUILD_TYPE}"
 
+# --- compute source-content hash for the helper's dependencies ----------------
+# When any source file compiled into cef_helper changes, the hash embedded in
+# the stamp won't match and the helper (together with the wrapper) is rebuilt on
+# the next pod install. This prevents stale renderer-process binaries that would
+# still run old V8 extension code (e.g. the retired |external| namespace) after
+# devs edit common/*.cc.
+HELPER_SOURCES=(
+  "${MACOS_DIR}/helper/cef_helper_main.mm"
+  "${REPO_ROOT}/common/webview_app.h"
+  "${REPO_ROOT}/common/webview_app.cc"
+  "${REPO_ROOT}/common/webview_handler.h"
+  "${REPO_ROOT}/common/webview_handler.cc"
+  "${REPO_ROOT}/common/webview_cookieVisitor.h"
+  "${REPO_ROOT}/common/webview_cookieVisitor.cc"
+  "${REPO_ROOT}/common/webview_js_handler.h"
+  "${REPO_ROOT}/common/webview_js_handler.cc"
+  "${REPO_ROOT}/common/webview_plugin.h"
+  "${REPO_ROOT}/common/webview_plugin.cc"
+  "${REPO_ROOT}/common/webview_value.h"
+  "${REPO_ROOT}/common/webview_value.cc"
+)
+SOURCE_HASH=$(cat "${HELPER_SOURCES[@]}" 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+WANT="${WANT}_${SOURCE_HASH}"
+
 # --- skip if already prepared for this exact version/arch/type ---------------
 if [ -f "${STAMP}" ] && [ "$(cat "${STAMP}" 2>/dev/null)" = "${WANT}" ] \
    && [ -f "${DEST}/libcef_dll_wrapper.a" ] \

--- a/macos/scripts/download_cef.sh
+++ b/macos/scripts/download_cef.sh
@@ -91,11 +91,42 @@ TARBALL="${WORK}/${PKG}.tar.bz2"
 # CDN requires '+' percent-encoded as %2B.
 URL="${CDN}/$(printf '%s' "${PKG}.tar.bz2" | sed 's/+/%2B/g')"
 
-echo "==> Downloading ${PKG}.tar.bz2"
-curl -L --fail --connect-timeout 30 -o "${TARBALL}" "${URL}"
+echo "==> Downloading ${PKG}.tar.bz2 (from ${CDN})"
+# curl --retry does NOT cover error 18 (partial transfer) by default,
+# so we implement a bash-level retry loop with resume (-C -) support.
+# The server supports Range requests, so each attempt appends to the partial
+# file. This is critical when the CDN connection is unstable: even if every
+# attempt delivers only a few MB before being cut off, enough attempts will
+# eventually complete the download.
+MAX_ATTEMPTS=3
+RETRY_DELAY_SEC=5
+attempt=1
+while [ $attempt -le $MAX_ATTEMPTS ]; do
+  if [ -f "${TARBALL}" ]; then
+    downloaded=$(stat -f%z "${TARBALL}" 2>/dev/null || echo 0)
+    echo "  [${attempt}/${MAX_ATTEMPTS}] Resuming from ${downloaded} bytes ($(( downloaded * 100 / 280729682 ))%)"
+  else
+    echo "  [${attempt}/${MAX_ATTEMPTS}] Starting download..."
+  fi
+  if curl -L --fail --connect-timeout 30 --max-time 1800 \
+       --retry-all-errors --retry 3 --retry-delay 5 \
+       -C - -o "${TARBALL}" "${URL}"; then
+    echo "==> Download complete"
+    break
+  fi
+  rc=$?
+  echo "  curl exited with code ${rc}"
+  if [ $attempt -ge $MAX_ATTEMPTS ]; then
+    err "Download failed after ${MAX_ATTEMPTS} attempts"
+  fi
+  sleep $RETRY_DELAY_SEC
+  attempt=$((attempt + 1))
+done
 
 echo "==> Extracting"
-tar -xjf "${TARBALL}" -C "${WORK}"
+if ! tar -xjf "${TARBALL}" -C "${WORK}"; then
+  err "Extraction failed — the downloaded archive may be corrupted. Try removing any cached partial download and re-run."
+fi
 SRC="${WORK}/${PKG}"
 [ -d "${SRC}" ] || err "extracted dir ${SRC} not found"
 

--- a/macos/webview_cef.podspec
+++ b/macos/webview_cef.podspec
@@ -33,28 +33,42 @@ Flutter webview backed by CEF (Chromium Embedded Framework)
   s.xcconfig = { "HEADER_SEARCH_PATHS" => $dir}
   # s.private_header_files = '../common/simple_app.h', '../common/simple_handler.h'
 
-  # CEF ships separate per-architecture macOS binaries; scripts/download_cef.sh
-  # fetches the one matching the build host (arm64 -> macosarm64, x86_64 ->
-  # macosx64). Exclude the other architecture so a default (universal)
-  # `flutter build macos` doesn't try to link a slice the CEF framework/wrapper
-  # doesn't provide — that fails with "symbol(s) not found for architecture
-  # x86_64". A universal app would require a lipo'd CEF, which is out of scope.
-  host_arch = `uname -m`.strip
-  non_host_arch = (host_arch == 'arm64') ? 'x86_64' : 'arm64'
+  # CEF dual-architecture support: download_cef.sh downloads both macosarm64
+  # and macosx64 packages by default, builds each separately, and merges them
+  # with lipo into universal binaries. No architectures are excluded — Xcode
+  # builds universal by default (ARCHS_STANDARD = arm64 x86_64).
+  #
+  # Set CEF_UNIVERSAL=0 to fall back to single host-architecture mode
+  # (emergency escape hatch for low-disk / poor-network situations).
+  universal_disabled = ENV['CEF_UNIVERSAL'] == '0'
 
   s.platform = :osx, '12.0'
   # CEF 149 public headers require C++20.
-  s.pod_target_xcconfig = {
-    'DEFINES_MODULE' => 'YES',
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
-    "EXCLUDED_ARCHS[sdk=macosx*]" => non_host_arch,
-    # Zero-copy GPU rendering: CEF delivers frames as a shared-texture IOSurface
-    # via OnAcceleratedPaint instead of a software CPU buffer (OnPaint). The IME
-    # and frame plumbing key off this define in the shared common/ sources.
-    'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) WEBVIEW_CEF_GPU_TEXTURE=1',
-  }
-  # The app target links the CEF framework/wrapper too, so it must drop the same
-  # architecture or its slice fails to link.
-  s.user_target_xcconfig = { "EXCLUDED_ARCHS[sdk=macosx*]" => non_host_arch }
+  if universal_disabled
+    host_arch = `uname -m`.strip
+    non_host_arch = (host_arch == 'arm64') ? 'x86_64' : 'arm64'
+
+    s.pod_target_xcconfig = {
+      'DEFINES_MODULE' => 'YES',
+      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
+      "EXCLUDED_ARCHS[sdk=macosx*]" => non_host_arch,
+      # Zero-copy GPU rendering: CEF delivers frames as a shared-texture IOSurface
+      # via OnAcceleratedPaint instead of a software CPU buffer (OnPaint). The IME
+      # and frame plumbing key off this define in the shared common/ sources.
+      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) WEBVIEW_CEF_GPU_TEXTURE=1',
+    }
+    # The app target links the CEF framework/wrapper too, so it must drop the same
+    # architecture or its slice fails to link.
+    s.user_target_xcconfig = { "EXCLUDED_ARCHS[sdk=macosx*]" => non_host_arch }
+  else
+    s.pod_target_xcconfig = {
+      'DEFINES_MODULE' => 'YES',
+      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
+      # Zero-copy GPU rendering: CEF delivers frames as a shared-texture IOSurface
+      # via OnAcceleratedPaint instead of a software CPU buffer (OnPaint). The IME
+      # and frame plumbing key off this define in the shared common/ sources.
+      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) WEBVIEW_CEF_GPU_TEXTURE=1',
+    }
+  end
   s.swift_version = '5.0'
 end

--- a/web-playground/bridge.html
+++ b/web-playground/bridge.html
@@ -85,11 +85,11 @@
 
     // ── 2. Print JavaScriptChannel ──────────────────
     function testChannel() {
-      if (typeof Print !== 'undefined') {
-        Print.postMessage(JSON.stringify({ msg: 'hello_from_print_channel' }));
-        appendLog('Channel', '<code>Print.postMessage(...)</code> sent');
+      if (typeof $cef !== 'undefined' && typeof $cef.Print !== 'undefined') {
+        $cef.Print.postMessage(JSON.stringify({ msg: 'hello_from_print_channel' }));
+        appendLog('Channel', '<code>$cef.Print.postMessage(...)</code> sent');
       } else {
-        appendLog('Channel', '<span style="color:#e94560">Print channel NOT registered</span>');
+        appendLog('Channel', '<span style="color:#e94560">$cef.Print channel NOT registered</span>');
       }
     }
 

--- a/web-playground/bridge.html
+++ b/web-playground/bridge.html
@@ -1,45 +1,123 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <title>JSBridge Test</title>
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       background: #1a1a2e;
       color: #e0e0e0;
-      display: flex; justify-content: center; align-items: center;
-      min-height: 100vh; padding: 20px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      padding: 20px;
     }
+
     .card {
-      background: #16213e; border-radius: 12px;
-      padding: 40px; max-width: 480px; width: 100%;
-      box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+      background: #16213e;
+      border-radius: 12px;
+      padding: 40px;
+      max-width: 480px;
+      width: 100%;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
     }
-    h1 { font-size: 1.6rem; color: #e94560; margin-bottom: 8px; }
-    .subtitle { font-size: 0.85rem; color: #a0a0b0; margin-bottom: 28px; }
-    .btn-group { display: flex; flex-direction: column; gap: 12px; }
+
+    h1 {
+      font-size: 1.6rem;
+      color: #e94560;
+      margin-bottom: 8px;
+    }
+
+    .subtitle {
+      font-size: 0.85rem;
+      color: #a0a0b0;
+      margin-bottom: 28px;
+    }
+
+    .btn-group {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
     button {
-      padding: 12px 20px; border: none; border-radius: 8px;
-      font-size: 0.95rem; cursor: pointer; font-weight: 600;
+      padding: 12px 20px;
+      border: none;
+      border-radius: 8px;
+      font-size: 0.95rem;
+      cursor: pointer;
+      font-weight: 600;
       transition: opacity 0.2s;
     }
-    button:hover { opacity: 0.85; }
-    button:active { opacity: 0.7; }
-    .btn-console   { background: #533483; color: #fff; }
-    .btn-channel   { background: #e94560; color: #fff; }
-    .btn-eval      { background: #0f3460; color: #fff; }
-    .btn-clear     { background: #2a2a4a; color: #a0a0b0; }
-    #log-area {
-      margin-top: 24px; background: #0d0d1a; border-radius: 8px;
-      padding: 14px; max-height: 260px; overflow-y: auto;
-      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.78rem;
-      line-height: 1.6; white-space: pre-wrap; word-break: break-all;
+
+    button:hover {
+      opacity: 0.85;
     }
-    .log-line { border-bottom: 1px solid #1a1a2e; padding: 3px 0; }
+
+    button:active {
+      opacity: 0.7;
+    }
+
+    .btn-console {
+      background: #533483;
+      color: #fff;
+    }
+
+    .btn-channel {
+      background: #e94560;
+      color: #fff;
+    }
+
+    .btn-eval {
+      background: #0f3460;
+      color: #fff;
+    }
+
+    .btn-clear {
+      background: #2a2a4a;
+      color: #a0a0b0;
+    }
+
+    .section {
+      margin-top: 20px;
+    }
+
+    .section-label {
+      font-size: 0.8rem;
+      color: #a0a0b0;
+      margin-bottom: 6px;
+    }
+
+    #log-area {
+      margin-top: 24px;
+      background: #0d0d1a;
+      border-radius: 8px;
+      padding: 14px;
+      max-height: 260px;
+      overflow-y: auto;
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      font-size: 0.78rem;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .log-line {
+      border-bottom: 1px solid #1a1a2e;
+      padding: 3px 0;
+    }
   </style>
 </head>
+
 <body>
   <div class="card">
     <h1>&#x26A1; JSBridge Sanity Check</h1>
@@ -58,6 +136,14 @@
       <button class="btn-clear" onclick="clearLog()">
         &#x1F5D1; Clear Log
       </button>
+    </div>
+
+    <div class="section">
+      <p class="section-label">Keyboard Shortcut Test</p>
+      <textarea id="shortcut-test" placeholder="Type here and test Cmd+Arrows, Cmd+Z, Cmd+Backspace..." style="width:100%;height:120px;background:#0d0d1a;color:#e0e0e0;
+          border:1px solid #2a2a4a;border-radius:8px;padding:10px;
+          font-family:'SF Mono','Fira Code',monospace;font-size:0.85rem;
+          resize:vertical;"></textarea>
     </div>
 
     <div id="log-area"></div>
@@ -108,4 +194,5 @@
     console.log('bridge.html ready');
   </script>
 </body>
+
 </html>

--- a/web-playground/bridge.html
+++ b/web-playground/bridge.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>JSBridge Test</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      display: flex; justify-content: center; align-items: center;
+      min-height: 100vh; padding: 20px;
+    }
+    .card {
+      background: #16213e; border-radius: 12px;
+      padding: 40px; max-width: 480px; width: 100%;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+    }
+    h1 { font-size: 1.6rem; color: #e94560; margin-bottom: 8px; }
+    .subtitle { font-size: 0.85rem; color: #a0a0b0; margin-bottom: 28px; }
+    .btn-group { display: flex; flex-direction: column; gap: 12px; }
+    button {
+      padding: 12px 20px; border: none; border-radius: 8px;
+      font-size: 0.95rem; cursor: pointer; font-weight: 600;
+      transition: opacity 0.2s;
+    }
+    button:hover { opacity: 0.85; }
+    button:active { opacity: 0.7; }
+    .btn-console   { background: #533483; color: #fff; }
+    .btn-channel   { background: #e94560; color: #fff; }
+    .btn-eval      { background: #0f3460; color: #fff; }
+    .btn-clear     { background: #2a2a4a; color: #a0a0b0; }
+    #log-area {
+      margin-top: 24px; background: #0d0d1a; border-radius: 8px;
+      padding: 14px; max-height: 260px; overflow-y: auto;
+      font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.78rem;
+      line-height: 1.6; white-space: pre-wrap; word-break: break-all;
+    }
+    .log-line { border-bottom: 1px solid #1a1a2e; padding: 3px 0; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>&#x26A1; JSBridge Sanity Check</h1>
+    <p class="subtitle">CEF WebView — console &middot; channel &middot; eval</p>
+
+    <div class="btn-group">
+      <button class="btn-console" onclick="testConsole()">
+        &#x1F4AC; 1. console.log
+      </button>
+      <button class="btn-channel" onclick="testChannel()">
+        &#x1F4E8; 2. Print Channel
+      </button>
+      <button class="btn-eval" onclick="testEval()">
+        &#x26A1; 3. evaluateJavascript
+      </button>
+      <button class="btn-clear" onclick="clearLog()">
+        &#x1F5D1; Clear Log
+      </button>
+    </div>
+
+    <div id="log-area"></div>
+  </div>
+
+  <script>
+    const logArea = document.getElementById('log-area');
+
+    function appendLog(tag, msg) {
+      const t = new Date().toLocaleTimeString();
+      logArea.innerHTML += `<div class="log-line">[${t}] <b>${tag}</b>: ${msg}</div>`;
+      logArea.scrollTop = logArea.scrollHeight;
+    }
+
+    function clearLog() {
+      logArea.innerHTML = '';
+      appendLog('UI', 'Log cleared');
+    }
+
+    // ── 1. console.log ──────────────────────────────
+    function testConsole() {
+      console.log('hello_from_console_log');
+      appendLog('Console', '<code>console.log("hello_from_console_log")</code> sent');
+    }
+
+    // ── 2. Print JavaScriptChannel ──────────────────
+    function testChannel() {
+      if (typeof Print !== 'undefined') {
+        Print.postMessage(JSON.stringify({ msg: 'hello_from_print_channel' }));
+        appendLog('Channel', '<code>Print.postMessage(...)</code> sent');
+      } else {
+        appendLog('Channel', '<span style="color:#e94560">Print channel NOT registered</span>');
+      }
+    }
+
+    // ── 3. evaluateJavascript (abc function) ────────
+    function testEval() {
+      if (typeof abc === 'function') {
+        var result = abc('bridge_test');
+        appendLog('Eval', '<code>abc("bridge_test")</code> → <b>' + result + '</b>');
+      } else {
+        appendLog('Eval', '<span style="color:#e94560">abc() NOT defined</span>');
+      }
+    }
+
+    // Boot log
+    appendLog('Init', 'bridge.html loaded');
+    console.log('bridge.html ready');
+  </script>
+</body>
+</html>

--- a/web-playground/bridge.html
+++ b/web-playground/bridge.html
@@ -115,6 +115,16 @@
       border-bottom: 1px solid #1a1a2e;
       padding: 3px 0;
     }
+    .file-row { display: flex; gap: 8px; align-items: center; }
+    .btn-file {
+      background: #1a6b3c; color: #fff; border: none; border-radius: 8px;
+      padding: 8px 16px; font-size: 0.85rem; font-weight: 600; cursor: pointer;
+      transition: opacity 0.2s; white-space: nowrap;
+    }
+    .btn-file:hover { opacity: 0.85; }
+    .btn-file:active { opacity: 0.7; }
+    #file-name { font-size: 0.78rem; color: #a0a0b0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    #file-info { margin-top: 6px; font-size: 0.75rem; color: #707088; min-height: 1em; }
   </style>
 </head>
 
@@ -144,6 +154,18 @@
           border:1px solid #2a2a4a;border-radius:8px;padding:10px;
           font-family:'SF Mono','Fira Code',monospace;font-size:0.85rem;
           resize:vertical;"></textarea>
+    </div>
+
+    <div class="section">
+      <p class="section-label">File Picker Test</p>
+      <div class="file-row">
+        <input type="file" id="file-input" style="display:none" onchange="onFileSelected(this.files)" />
+        <button class="btn-file" onclick="document.getElementById('file-input').click()">
+          &#x1F4C2; Choose File
+        </button>
+        <span id="file-name">No file chosen</span>
+      </div>
+      <div id="file-info"></div>
     </div>
 
     <div id="log-area"></div>
@@ -186,6 +208,36 @@
         appendLog('Eval', '<code>abc("bridge_test")</code> → <b>' + result + '</b>');
       } else {
         appendLog('Eval', '<span style="color:#e94560">abc() NOT defined</span>');
+      }
+    }
+
+    // ── 4. File Picker ──────────────────────────────
+    function onFileSelected(files) {
+      var el = document.getElementById('file-name');
+      var info = document.getElementById('file-info');
+      if (!files || files.length === 0) {
+        el.textContent = 'No file chosen';
+        info.textContent = '';
+        return;
+      }
+      var f = files[0];
+      var size = f.size < 1024 ? f.size + ' B'
+        : f.size < 1048576 ? (f.size / 1024).toFixed(1) + ' KB'
+        : (f.size / 1048576).toFixed(2) + ' MB';
+      el.textContent = f.name;
+      info.textContent = 'Type: ' + (f.type || 'unknown') + '  |  Size: ' + size;
+      appendLog('File', '<b>' + f.name + '</b> — ' + size + ' (' + (f.type || 'unknown') + ')');
+
+      // Read the file content as text (up to 4 KB) and display a preview.
+      if (f.size <= 4096) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          appendLog('File', 'Content preview: <pre style="margin:4px 0 0 0;font-size:0.72rem;opacity:0.8">'
+            + e.target.result + '</pre>');
+        };
+        reader.readAsText(f);
+      } else {
+        appendLog('File', 'File too large for preview (>4 KB)');
       }
     }
 

--- a/windows/webview_cef_keyevent.h
+++ b/windows/webview_cef_keyevent.h
@@ -90,7 +90,7 @@ int GetCefKeyboardModifiers(WPARAM wparam, LPARAM lparam)
 
 CefKeyEvent getCefKeyEvent(UINT message, WPARAM wparam, LPARAM lparam)
 {
-    CefKeyEvent event;
+    CefKeyEvent event = {};
     event.windows_key_code = (int)wparam;
     event.native_key_code = (int)lparam;
     event.is_system_key = message == WM_SYSCHAR || message == WM_SYSKEYDOWN ||

--- a/windows/webview_cef_plugin.cpp
+++ b/windows/webview_cef_plugin.cpp
@@ -400,6 +400,29 @@ namespace webview_cef {
 		
 	WebviewCefPlugin::WebviewCefPlugin() {
 		m_plugin = std::make_shared<WebviewPlugin>();
+
+		// Derive a default CEF cache path from the executable name so that
+		// multiple apps embedding the same CEF framework each get their own
+		// isolated cache directory.  If the Dart layer provides a cachePath
+		// via initialize(), it will override this default in startCEF().
+		wchar_t exePath[MAX_PATH] = {};
+		if (GetModuleFileNameW(nullptr, exePath, MAX_PATH) > 0) {
+			std::wstring ws(exePath);
+			size_t lastSlash = ws.find_last_of(L"\\/");
+			size_t lastDot   = ws.find_last_of(L'.');
+			std::wstring exeName = ws.substr(
+				lastSlash == std::wstring::npos ? 0 : lastSlash + 1,
+				(lastDot == std::wstring::npos || lastDot < lastSlash)
+					? std::wstring::npos
+					: lastDot - lastSlash - 1);
+			char localAppData[MAX_PATH] = {};
+			if (GetEnvironmentVariableA("LOCALAPPDATA", localAppData, MAX_PATH) > 0) {
+				std::string cachePath = std::string(localAppData) + "\\"
+					+ std::string(exeName.begin(), exeName.end())
+					+ "\\cef";
+				webview_cef::setCefCachePath(cachePath);
+			}
+		}
 	}
 
 	WebviewCefPlugin::~WebviewCefPlugin() {


### PR DESCRIPTION
1. CEF off-screen rendering bypasses AppKit's interpretKeyEvents: which normally
maps Cmd+Backspace to the deleteToBeginningOfLine editing command. Intercept
the shortcut in WebviewPlugin::sendKeyEvent() and execute the editing action
via JavaScript (Selection API + execCommand('delete')).

3. Through the newly added progress bar overlay and alert dialog examples, this demonstrates that Flutter native widgets can be easily layered on top of web content without being obstructed by the WebView.