### PR TITLE
macOS: universal (arm64 + x86_64) builds via WEBVIEW_CEF_MACOS_ARCH

### DIFF
--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -54,3 +54,54 @@ jobs:
         working-directory: example
         run: flutter analyze
       - run: cd example && flutter build macos
+
+  universal:
+    # Universal (arm64 + x86_64) build: WEBVIEW_CEF_MACOS_ARCH=universal makes
+    # the podspec keep both architectures and download_cef.sh lipo the CEF
+    # framework, wrapper and helper. Everything is prepared by `pod install`,
+    # so nothing is downloaded by hand here.
+    runs-on: macos-latest
+    env:
+      WEBVIEW_CEF_MACOS_ARCH: universal
+      CEF_WRAPPER_BUILD_TYPE: Release
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install build tools
+        run: brew install ninja cmake
+      - name: Build example app
+        working-directory: example
+        run: flutter build macos --release
+      - name: Check every Mach-O binary is universal
+        run: |
+          set -eo pipefail
+          app="$(ls -d example/build/macos/Build/Products/Release/*.app | head -1)"
+          fw="${app}/Contents/Frameworks/Chromium Embedded Framework.framework"
+          binaries=("${app}/Contents/MacOS/"* "${fw}/Chromium Embedded Framework" "${fw}/Libraries/"*.dylib)
+          # The five CEF helper .app bundles embedded by embed_cef_helpers.sh.
+          helpers=("${app}/Contents/Frameworks/"*Helper*.app)
+          if [ "${#helpers[@]}" -ne 5 ]; then
+            echo "::error::expected 5 embedded CEF helper bundles, found ${#helpers[@]}"
+            exit 1
+          fi
+          for helper in "${helpers[@]}"; do
+            binaries+=("${helper}/Contents/MacOS/"*)
+          done
+          status=0
+          for binary in "${binaries[@]}"; do
+            archs="$(lipo -archs "${binary}" 2>/dev/null || echo "")"
+            echo "${archs:-<not mach-o>}  ${binary#${app}/}"
+            case " ${archs} " in
+              *" arm64 "*) ;;
+              *) echo "::error::${binary} has no arm64 slice"; status=1 ;;
+            esac
+            case " ${archs} " in
+              *" x86_64 "*) ;;
+              *) echo "::error::${binary} has no x86_64 slice"; status=1 ;;
+            esac
+          done
+          exit ${status}

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -94,3 +94,21 @@ jobs:
             esac
           done
           exit ${status}
+      - name: Check both V8 context snapshots are present
+        run: |
+          set -eo pipefail
+          app="$(ls -d example/build/macos/Build/Products/Release/*.app | head -1)"
+          res="${app}/Contents/Frameworks/Chromium Embedded Framework.framework/Resources"
+          status=0
+          # Chromium picks v8_context_snapshot.<arch>.bin at runtime, so a
+          # universal app needs both — fat Mach-O files alone are not enough.
+          for arch in arm64 x86_64; do
+            snapshot="${res}/v8_context_snapshot.${arch}.bin"
+            if [ -f "${snapshot}" ]; then
+              echo "$(stat -f%z "${snapshot}") bytes  v8_context_snapshot.${arch}.bin"
+            else
+              echo "::error::missing v8_context_snapshot.${arch}.bin"
+              status=1
+            fi
+          done
+          exit ${status}

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -31,22 +31,12 @@ jobs:
           channel: stable
       - name: Install build tools
         run: brew install ninja cmake
-      # macOS uses CocoaPods (not third/download.cmake), so the CEF framework and
-      # libcef_dll_wrapper must be placed into macos/third/cef manually.
-      # Keep CEF_VERSION in sync with third/download.cmake.
+      # Prepare macos/third/cef with the same script the podspec's
+      # prepare_command runs, so the CEF version comes from third/download.cmake
+      # instead of being pinned a second time here. `pod install` then finds it
+      # already prepared and does not download CEF again.
       - name: Download CEF and build libcef_dll_wrapper
-        run: |
-          set -eo pipefail
-          CEF_VERSION="149.0.4+g2f1bfd8+chromium-149.0.7827.156"
-          NAME="cef_binary_${CEF_VERSION}_macosarm64"
-          URL_NAME=$(printf '%s' "$NAME" | sed 's/+/%2B/g')
-          curl -L -o cef.tar.bz2 "https://cef-builds.spotifycdn.com/${URL_NAME}.tar.bz2"
-          tar -xjf cef.tar.bz2
-          cmake -S "$NAME" -B "$NAME/build" -G Ninja -DPROJECT_ARCH=arm64 -DCMAKE_BUILD_TYPE=Release
-          cmake --build "$NAME/build" --target libcef_dll_wrapper
-          mkdir -p macos/third/cef
-          cp -R "$NAME/Release/Chromium Embedded Framework.framework" macos/third/cef/
-          cp "$NAME/build/libcef_dll_wrapper/libcef_dll_wrapper.a" macos/third/cef/
+        run: bash macos/scripts/download_cef.sh
       - run: flutter --version
       - name: Analyze plugin
         run: flutter analyze

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -53,7 +53,6 @@ jobs:
     runs-on: macos-latest
     env:
       WEBVIEW_CEF_MACOS_ARCH: universal
-      CEF_WRAPPER_BUILD_TYPE: Release
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- macOS: added universal (arm64 + x86_64) builds. `WEBVIEW_CEF_MACOS_ARCH` (`host`, `arm64`, `x86_64`, `universal`) is read by both `macos/scripts/download_cef.sh` and the podspec, so the prepared CEF slices and `EXCLUDED_ARCHS` always match; the framework, its ANGLE/SwiftShader dylibs, `libcef_dll_wrapper.a`, and the helper executable are merged with `lipo` and verified, and the helper embed phase fails the build if the helper does not cover every architecture being built.
+
 ## 0.6.1
 - Fixed Linux runner source detection for current Flutter projects using `linux/runner/`, while retaining compatibility with the legacy `linux/` layout.
 - Added regression coverage for both Linux runner layouts and clearer build failures when runner sources cannot be patched.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A Flutter **desktop** WebView backed by [CEF](https://bitbucket.org/chromiumembe
 | Platform | Minimum version | Architectures |
 | --- | --- | --- |
 | Windows | Windows 10 | x64 |
-| macOS  | macOS 12.0 | arm64 or x86_64 (host arch only — no universal build) |
+| macOS  | macOS 12.0 | arm64, x86_64, or universal (arm64 + x86_64) |
 | Linux  | — | x64, arm64 |
 | eLinux | — | x64, arm64 |
 
@@ -45,7 +45,7 @@ A Flutter **desktop** WebView backed by [CEF](https://bitbucket.org/chromiumembe
 - **Toolchain** — upgrade to Flutter **≥ 3.27.0** / Dart **≥ 3.6.0** (was 2.5.0 / 2.17.1). The native build now requires **C++20** (CEF 149); make sure your app doesn't force the plugin target to an older C++ standard.
 - **Removed Dart API** — `WebviewCefPlatform`, `MethodChannelWebviewCef`, and `getPlatformVersion()` were removed (along with the `plugin_platform_interface` dependency). They were never the intended API and have no replacement (`getPlatformVersion` returned a demo value). Import only `package:webview_cef/webview_cef.dart` and use `WebviewManager` / `WebViewController`.
 - **Windows** — `initCEFProcesses` changed signature. Update `windows/runner/main.cpp`: it now takes the `HINSTANCE` and returns a sub-process exit code that must be returned immediately, as the first statement in `wWinMain` (see the Windows install snippet below). The minimum OS is now **Windows 10**.
-- **macOS** — raise the deployment target to **12.0**: set `platform :osx, '12.0'` in `macos/Podfile` **and** the Runner target's macOS Deployment Target in Xcode (CEF 149's framework is built for 12.0). To enable multi-process rendering, add the one-line `post_install` hook to `macos/Podfile` (see the macOS install section). Builds are now **host-architecture only** (arm64 *or* x86_64) — universal macOS apps are no longer produced.
+- **macOS** — raise the deployment target to **12.0**: set `platform :osx, '12.0'` in `macos/Podfile` **and** the Runner target's macOS Deployment Target in Xcode (CEF 149's framework is built for 12.0). To enable multi-process rendering, add the one-line `post_install` hook to `macos/Podfile` (see the macOS install section). Builds target the **host architecture** by default (arm64 *or* x86_64); set `WEBVIEW_CEF_MACOS_ARCH=universal` before `pod install` for a universal (arm64 + x86_64) app.
 
 ---
 
@@ -115,13 +115,29 @@ On the first build, the official CEF *Standard Distribution* (~330 MB, from <htt
 
    Then `pod install` (run automatically by `flutter run`). This installs an "Embed CEF Helpers" build phase that clones the prebuilt helper into the five CEF sub-process `.app` bundles inside your app — no manual Xcode target needed. **Without this hook the plugin still works but falls back to single-process** (an unsupported Chromium mode: no crash isolation, V8 proxy resolver disabled, etc.).
 
-macOS uses CocoaPods, which does not run the CMake download path. Instead the podspec's `prepare_command` runs [`macos/scripts/download_cef.sh`](macos/scripts/download_cef.sh) on `pod install`, which mirrors the Windows/Linux flow: it downloads the official CEF *Standard Distribution* for your arch (from <https://cef-builds.spotifycdn.com>, version pinned by `CEF_VERSION` in [`third/download.cmake`](third/download.cmake)), compiles `libcef_dll_wrapper` from source, lays the framework out as a versioned macOS bundle, and installs everything into the (git-ignored) `macos/third/cef`. The first `pod install` therefore takes noticeably longer; subsequent runs are a no-op once the pinned version is present.
+macOS uses CocoaPods, which does not run the CMake download path. Instead the podspec's `prepare_command` runs [`macos/scripts/download_cef.sh`](macos/scripts/download_cef.sh) on `pod install`, which mirrors the Windows/Linux flow: it downloads the official CEF *Standard Distribution* for the selected architecture (from <https://cef-builds.spotifycdn.com>, version pinned by `CEF_VERSION` in [`third/download.cmake`](third/download.cmake)), compiles `libcef_dll_wrapper` from source, lays the framework out as a versioned macOS bundle, and installs everything into the (git-ignored) `macos/third/cef`. The first `pod install` therefore takes noticeably longer; subsequent runs are a no-op once the pinned version is present.
 
 Requirements: `cmake` (and `ninja`, otherwise `make` is used) must be on `PATH` to build the wrapper — `brew install cmake ninja`.
 
 > The wrapper is built `Debug` by default to match `flutter run` / `flutter build macos --debug`. For a release build set `CEF_WRAPPER_BUILD_TYPE=Release` before `pod install` (debug and release builds need a wrapper compiled in the matching configuration — `#if DCHECK_IS_ON()` changes its ABI).
 
-> The script builds for the host arch only (arm64 **or** x86_64). For a Universal (arm64 + x86_64) app, `lipo` the wrapper and use a universal framework — see [#30](/../../issues/30). **`[HELP WANTED]`** a more elegant binary distribution.
+#### Choosing the architecture
+
+`WEBVIEW_CEF_MACOS_ARCH` selects which slices are prepared. It is read by both the download script and the podspec, so the CEF binaries and the `EXCLUDED_ARCHS` of your app always agree.
+
+| Value | Result |
+| --- | --- |
+| `host` (default) | the build machine's architecture |
+| `arm64` | Apple Silicon only |
+| `x86_64` | Intel only |
+| `universal` | both, merged with `lipo` |
+
+```bash
+WEBVIEW_CEF_MACOS_ARCH=universal CEF_WRAPPER_BUILD_TYPE=Release pod install
+cd .. && flutter build macos --release
+```
+
+A universal build downloads both CEF distributions and compiles the wrapper twice, so it takes about twice as long and needs roughly 8 GB of free scratch space. The framework binary, the ANGLE/SwiftShader dylibs beside it, `libcef_dll_wrapper.a`, and the helper executable are merged with `lipo`, then each is checked for the expected slices; the "Embed CEF Helpers" build phase fails the build if the helper does not cover every architecture the app is being built for. The selected value is recorded in `macos/third/cef/version.txt`, so changing it re-prepares `macos/third/cef` on the next `pod install`.
 
 ### Linux
 
@@ -334,7 +350,7 @@ The CEF/Chromium version is pinned in one place — `CEF_VERSION` in [`third/dow
 - [x] DevTools
 - [x] GPU zero-copy rendering & adaptive frame rate (Windows & macOS)
 - [x] Easier macOS multi-process helper-bundle integration (one-line Podfile hook)
-- [ ] Universal (arm64 + x86_64) macOS builds (needs a lipo'd CEF)
+- [x] Universal (arm64 + x86_64) macOS builds
 - [ ] Tear-free GPU sync (keyed-mutex) on Windows
 
 Pull requests are welcome. Every PR runs build + `flutter analyze` CI on Windows, macOS, and Linux.

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ These CMake options can be set on the plugin target (defaults shown):
 
 ## Updating CEF
 
-The CEF/Chromium version is pinned in one place — `CEF_VERSION` in [`third/download.cmake`](third/download.cmake). Bump it to update CEF on all three platforms: Windows and Linux download it automatically, and macOS reads the same `CEF_VERSION` (via `macos/scripts/download_cef.sh`, run by the podspec's `prepare_command`) and re-downloads on the next `pod install` — no manual placement needed. The only extra step is keeping the hardcoded `CEF_VERSION` in [`.github/workflows/test_macos.yaml`](.github/workflows/test_macos.yaml) in sync.
+The CEF/Chromium version is pinned in one place — `CEF_VERSION` in [`third/download.cmake`](third/download.cmake). Bump it to update CEF on all three platforms: Windows and Linux download it automatically, and macOS reads the same `CEF_VERSION` (via `macos/scripts/download_cef.sh`, run by the podspec's `prepare_command`) and re-downloads on the next `pod install` — no manual placement needed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ WEBVIEW_CEF_MACOS_ARCH=universal pod install
 cd .. && flutter build macos --release
 ```
 
-A universal build downloads both CEF distributions and compiles the wrapper twice, so it takes about twice as long and needs roughly 8 GB of free scratch space. The framework binary, the ANGLE/SwiftShader dylibs beside it, `libcef_dll_wrapper.a`, and the helper executable are merged with `lipo`, then each is checked for the expected slices; the "Embed CEF Helpers" build phase fails the build if the helper does not cover every architecture the app is being built for. The selected value is recorded in `macos/third/cef/version.txt`, so changing it re-prepares `macos/third/cef` on the next `pod install`.
+A universal build downloads both CEF distributions and compiles the wrapper twice, so it takes about twice as long and needs roughly 8 GB of free scratch space. The framework binary, the ANGLE/SwiftShader dylibs beside it, `libcef_dll_wrapper.a`, and the helper executable are merged with `lipo`, then each is checked for the expected slices. Chromium's V8 startup snapshot is architecture specific (`v8_context_snapshot.<arch>.bin`), so both are copied into the framework's `Resources` and the right one is picked at runtime; the "Embed CEF Helpers" build phase fails the build if the helper does not cover every architecture the app is being built for. The selected value is recorded in `macos/third/cef/version.txt`, so changing it re-prepares `macos/third/cef` on the next `pod install`.
 
 ### Linux
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Requirements: `cmake` (and `ninja`, otherwise `make` is used) must be on `PATH` 
 | `universal` | both, merged with `lipo` |
 
 ```bash
-WEBVIEW_CEF_MACOS_ARCH=universal CEF_WRAPPER_BUILD_TYPE=Release pod install
+WEBVIEW_CEF_MACOS_ARCH=universal pod install
 cd .. && flutter build macos --release
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -136,7 +136,7 @@ WEBVIEW_CEF_MACOS_ARCH=universal pod install
 cd .. && flutter build macos --release
 ```
 
-Universal 构建会下载两份 CEF 发行包并编译两次 wrapper，耗时约为原来的两倍，并需要约 8 GB 临时空间。framework 二进制、其旁边的 ANGLE/SwiftShader dylib、`libcef_dll_wrapper.a` 以及 helper 可执行文件都会用 `lipo` 合并，随后逐个校验切片是否齐全；若 helper 缺少 App 正在构建的某个架构，"Embed CEF Helpers" 构建阶段会直接报错。所选取值会写入 `macos/third/cef/version.txt`，因此改动后下次 `pod install` 会重新准备 `macos/third/cef`。
+Universal 构建会下载两份 CEF 发行包并编译两次 wrapper，耗时约为原来的两倍，并需要约 8 GB 临时空间。framework 二进制、其旁边的 ANGLE/SwiftShader dylib、`libcef_dll_wrapper.a` 以及 helper 可执行文件都会用 `lipo` 合并，随后逐个校验切片是否齐全。Chromium 的 V8 启动快照按架构区分文件名（`v8_context_snapshot.<arch>.bin`），两份都会放进 framework 的 `Resources`，运行时按架构选取；若 helper 缺少 App 正在构建的某个架构，"Embed CEF Helpers" 构建阶段会直接报错。所选取值会写入 `macos/third/cef/version.txt`，因此改动后下次 `pod install` 会重新准备 `macos/third/cef`。
 
 ### Linux
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -290,7 +290,7 @@ final controller = WebviewManager().createWebView(injectUserScripts: scripts);
 
 ## 升级 CEF
 
-CEF/Chromium 版本只在一处管理 —— [`third/download.cmake`](third/download.cmake) 里的 `CEF_VERSION`。修改它即可升级三端的 CEF：Windows 与 Linux 自动下载，macOS 也读取同一个 `CEF_VERSION`（通过 podspec `prepare_command` 运行的 [`macos/scripts/download_cef.sh`](macos/scripts/download_cef.sh)），在下次 `pod install` 时重新下载，无需手动放置。唯一的额外步骤是同步 [`.github/workflows/test_macos.yaml`](.github/workflows/test_macos.yaml) 里硬编码的 `CEF_VERSION`。
+CEF/Chromium 版本只在一处管理 —— [`third/download.cmake`](third/download.cmake) 里的 `CEF_VERSION`。修改它即可升级三端的 CEF：Windows 与 Linux 自动下载，macOS 也读取同一个 `CEF_VERSION`（通过 podspec `prepare_command` 运行的 [`macos/scripts/download_cef.sh`](macos/scripts/download_cef.sh)），在下次 `pod install` 时重新下载，无需手动放置。
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@
 | 平台 | 最低版本 | 架构 |
 | --- | --- | --- |
 | Windows | Windows 10 | x64 |
-| macOS | macOS 12.0 | arm64 或 x86_64（仅本机架构，非 Universal） |
+| macOS | macOS 12.0 | arm64、x86_64 或 Universal（arm64 + x86_64） |
 | Linux | — | x64、arm64 |
 
 ## 环境要求
@@ -44,7 +44,7 @@
 - **工具链** —— 升级到 Flutter **≥ 3.27.0** / Dart **≥ 3.6.0**（原为 2.5.0 / 2.17.1）。原生构建现在需要 **C++20**（CEF 149）；请确保你的工程没有把插件 target 强制设为更低的 C++ 标准。
 - **移除的 Dart API** —— `WebviewCefPlatform`、`MethodChannelWebviewCef`、`getPlatformVersion()` 已移除（同时移除了 `plugin_platform_interface` 依赖）。它们本就不是对外 API，且无替代（`getPlatformVersion` 仅返回演示值）。请只 import `package:webview_cef/webview_cef.dart`，使用 `WebviewManager` / `WebViewController`。
 - **Windows** —— `initCEFProcesses` 签名变更。请更新 `windows/runner/main.cpp`：它现在接收 `HINSTANCE` 并返回子进程退出码，且必须作为 `wWinMain` 的第一条语句立即返回（见下方 Windows 安装片段）。最低系统现为 **Windows 10**。
-- **macOS** —— 把部署目标提升到 **12.0**：在 `macos/Podfile` 设置 `platform :osx, '12.0'`，并在 Xcode 中把 Runner target 的 macOS Deployment Target 也设为 12.0（CEF 149 的 framework 以 12.0 构建）。要启用多进程渲染，请在 `macos/Podfile` 的 `post_install` 中加入一行钩子（见 macOS 安装一节）。构建现在**仅针对本机架构**（arm64 *或* x86_64）—— 不再生成 Universal 包。
+- **macOS** —— 把部署目标提升到 **12.0**：在 `macos/Podfile` 设置 `platform :osx, '12.0'`，并在 Xcode 中把 Runner target 的 macOS Deployment Target 也设为 12.0（CEF 149 的 framework 以 12.0 构建）。要启用多进程渲染，请在 `macos/Podfile` 的 `post_install` 中加入一行钩子（见 macOS 安装一节）。构建默认只针对**本机架构**（arm64 *或* x86_64）；在 `pod install` 前设置 `WEBVIEW_CEF_MACOS_ARCH=universal` 即可生成 Universal（arm64 + x86_64）App。
 
 ---
 
@@ -114,13 +114,29 @@
 
    然后 `pod install`(`flutter run` 会自动跑)。它会装一个 "Embed CEF Helpers" 构建阶段,把预编译的 helper 克隆成 5 个 CEF 子进程 `.app` 嵌进你的 App —— 无需手动加 Xcode target。**不加这个钩子插件也能用,但会回退单进程**(Chromium 不支持的模式:无崩溃隔离、V8 proxy resolver 被禁等)。
 
-macOS 走 CocoaPods，不跑 CMake 的下载流程。改由 podspec 的 `prepare_command` 在 `pod install` 时运行 [`macos/scripts/download_cef.sh`](macos/scripts/download_cef.sh)，逻辑与 Windows/Linux 对齐：下载与本机架构匹配的官方 CEF *Standard Distribution*（来自 <https://cef-builds.spotifycdn.com>，版本由 [`third/download.cmake`](third/download.cmake) 的 `CEF_VERSION` 固定），从源码编译 `libcef_dll_wrapper`，把 framework 整理成 versioned macOS bundle，并安装进（已 git-ignore 的）`macos/third/cef`。所以首次 `pod install` 会明显变慢；之后只要版本未变即为 no-op。
+macOS 走 CocoaPods，不跑 CMake 的下载流程。改由 podspec 的 `prepare_command` 在 `pod install` 时运行 [`macos/scripts/download_cef.sh`](macos/scripts/download_cef.sh)，逻辑与 Windows/Linux 对齐：下载所选架构的官方 CEF *Standard Distribution*（来自 <https://cef-builds.spotifycdn.com>，版本由 [`third/download.cmake`](third/download.cmake) 的 `CEF_VERSION` 固定），从源码编译 `libcef_dll_wrapper`，把 framework 整理成 versioned macOS bundle，并安装进（已 git-ignore 的）`macos/third/cef`。所以首次 `pod install` 会明显变慢；之后只要版本未变即为 no-op。
 
 要求：`PATH` 上需有 `cmake`（以及 `ninja`，否则退回 `make`）来编译 wrapper —— `brew install cmake ninja`。
 
 > wrapper 默认编 `Debug`，以匹配 `flutter run` / `flutter build macos --debug`。如需 release 构建，在 `pod install` 前设置 `CEF_WRAPPER_BUILD_TYPE=Release`（debug 与 release 需要对应配置编译的 wrapper —— `#if DCHECK_IS_ON()` 会改变其 ABI）。
 
-> 脚本只为本机架构编译（arm64 **或** x86_64）。如需 Universal（arm64 + x86_64）App，用 `lipo` 合并 wrapper 并使用 universal framework，详见 [#30](/../../issues/30)。**`[征集帮助]`** 更优雅的二进制分发方式。
+#### 选择架构
+
+`WEBVIEW_CEF_MACOS_ARCH` 决定准备哪些架构。下载脚本与 podspec 读取同一个变量，因此 CEF 二进制与 App 的 `EXCLUDED_ARCHS` 始终一致。
+
+| 取值 | 结果 |
+| --- | --- |
+| `host`（默认） | 构建机器的架构 |
+| `arm64` | 仅 Apple Silicon |
+| `x86_64` | 仅 Intel |
+| `universal` | 两者，用 `lipo` 合并 |
+
+```bash
+WEBVIEW_CEF_MACOS_ARCH=universal CEF_WRAPPER_BUILD_TYPE=Release pod install
+cd .. && flutter build macos --release
+```
+
+Universal 构建会下载两份 CEF 发行包并编译两次 wrapper，耗时约为原来的两倍，并需要约 8 GB 临时空间。framework 二进制、其旁边的 ANGLE/SwiftShader dylib、`libcef_dll_wrapper.a` 以及 helper 可执行文件都会用 `lipo` 合并，随后逐个校验切片是否齐全；若 helper 缺少 App 正在构建的某个架构，"Embed CEF Helpers" 构建阶段会直接报错。所选取值会写入 `macos/third/cef/version.txt`，因此改动后下次 `pod install` 会重新准备 `macos/third/cef`。
 
 ### Linux
 
@@ -301,7 +317,7 @@ CEF/Chromium 版本只在一处管理 —— [`third/download.cmake`](third/down
 - [x] DevTools
 - [x] GPU 零拷贝渲染与自适应帧率（Windows 与 macOS）
 - [x] 更简单的 macOS 多进程 helper bundle 集成（一行 Podfile 钩子）
-- [ ] macOS Universal（arm64 + x86_64）构建（需要 lipo 合并的 CEF）
+- [x] macOS Universal（arm64 + x86_64）构建
 - [ ] Windows 上无撕裂的 GPU 同步（keyed-mutex）
 
 欢迎提交 PR。每个 PR 都会在 Windows、macOS、Linux 上运行构建 + `flutter analyze` CI。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,7 +132,7 @@ macOS 走 CocoaPods，不跑 CMake 的下载流程。改由 podspec 的 `prepare
 | `universal` | 两者，用 `lipo` 合并 |
 
 ```bash
-WEBVIEW_CEF_MACOS_ARCH=universal CEF_WRAPPER_BUILD_TYPE=Release pod install
+WEBVIEW_CEF_MACOS_ARCH=universal pod install
 cd .. && flutter build macos --release
 ```
 

--- a/macos/scripts/download_cef.sh
+++ b/macos/scripts/download_cef.sh
@@ -153,9 +153,9 @@ lipo -create "${wrappers[@]}" -output "${DEST}/libcef_dll_wrapper.a"
 verify_archs "${DEST}/libcef_dll_wrapper.a"
 
 # Lay the framework out as a versioned macOS bundle (Xcode embed/sign requires
-# Versions/Current/Resources/Info.plist; CEF ships a flat bundle). The Resources
-# (locales, .pak/.dat blobs) are architecture independent, so they are taken
-# from the primary distribution; the Mach-O parts are merged.
+# Versions/Current/Resources/Info.plist; CEF ships a flat bundle). Most Resources
+# (locales, .pak/.dat blobs) are architecture independent, so they are taken from
+# the primary distribution; the Mach-O parts and the V8 snapshot are merged.
 FW_SRC="${PRIMARY}/Release/Chromium Embedded Framework.framework"
 FW_DST="${DEST}/Chromium Embedded Framework.framework"
 mkdir -p "${FW_DST}/Versions/A"
@@ -166,6 +166,18 @@ ln -sfn A "${FW_DST}/Versions/Current"
 ln -sfn "Versions/Current/Chromium Embedded Framework" "${FW_DST}/Chromium Embedded Framework"
 ln -sfn Versions/Current/Libraries "${FW_DST}/Libraries"
 ln -sfn Versions/Current/Resources "${FW_DST}/Resources"
+
+# The V8 startup snapshot is the one architecture-dependent resource. Chromium
+# names it per architecture (v8_context_snapshot.<arch>.bin) precisely so a
+# universal bundle can carry both and pick the right one at runtime, so each
+# distribution's snapshot has to be copied in — the Resources above only carry
+# the primary architecture's.
+for arch in "${ARCHS[@]}"; do
+  snapshot="v8_context_snapshot.${arch}.bin"
+  snapshot_src="${WORK}/$(cef_package "${arch}")/Release/Chromium Embedded Framework.framework/Resources/${snapshot}"
+  [ -f "${snapshot_src}" ] || err "${snapshot} not found in the ${arch} distribution"
+  cp "${snapshot_src}" "${FW_DST}/Versions/A/Resources/${snapshot}"
+done
 
 if [ "${#ARCHS[@]}" -gt 1 ]; then
   echo "==> Merging framework binaries (${ARCHS[*]})"

--- a/macos/scripts/download_cef.sh
+++ b/macos/scripts/download_cef.sh
@@ -15,6 +15,12 @@
 # of truth shared with Windows/Linux. Re-running is cheap: if the destination is
 # already populated for the pinned version it exits immediately.
 #
+# Architecture is selected with WEBVIEW_CEF_MACOS_ARCH:
+#   host (default)  the build host's architecture
+#   arm64           Apple Silicon only
+#   x86_64          Intel only
+#   universal       both, merged with lipo (needs ~8 GB of scratch space)
+#
 # Override the wrapper build type with CEF_WRAPPER_BUILD_TYPE=Release (defaults
 # to Debug to match `flutter run` / `flutter build macos --debug`).
 set -euo pipefail
@@ -34,15 +40,54 @@ err() { echo "error: $*" >&2; exit 1; }
 CEF_VERSION="$(sed -n 's/^[[:space:]]*set(CEF_VERSION[[:space:]]*"\(.*\)").*/\1/p' "${DOWNLOAD_CMAKE}" | head -1)"
 [ -n "${CEF_VERSION}" ] || err "could not parse CEF_VERSION from ${DOWNLOAD_CMAKE}"
 
+# --- resolve requested architecture(s) --------------------------------------
 case "$(uname -m)" in
-  arm64)  CEF_ARCH="macosarm64"; PROJECT_ARCH="arm64" ;;
-  x86_64) CEF_ARCH="macosx64";   PROJECT_ARCH="x86_64" ;;
-  *)      err "unsupported arch: $(uname -m)" ;;
+  arm64)  HOST_ARCH=arm64 ;;
+  x86_64) HOST_ARCH=x86_64 ;;
+  *)      err "unsupported host arch: $(uname -m)" ;;
 esac
 
-PKG="cef_binary_${CEF_VERSION}_${CEF_ARCH}"
+# The tag is part of the stamp file, so switching architectures re-prepares
+# third/cef instead of silently reusing the wrong slices.
+arch_tag() {
+  case "$1" in
+    arm64)  echo macosarm64 ;;
+    x86_64) echo macosx64 ;;
+  esac
+}
+
+REQUESTED="${WEBVIEW_CEF_MACOS_ARCH:-host}"
+[ "${REQUESTED}" = host ] && REQUESTED="${HOST_ARCH}"
+case "${REQUESTED}" in
+  arm64|x86_64) ARCHS=("${REQUESTED}"); ARCH_TAG="$(arch_tag "${REQUESTED}")" ;;
+  universal)    ARCHS=(arm64 x86_64);   ARCH_TAG="universal" ;;
+  *) err "WEBVIEW_CEF_MACOS_ARCH must be host, arm64, x86_64 or universal (got '${REQUESTED}')" ;;
+esac
+
+cef_package() {
+  case "$1" in
+    arm64)  echo "cef_binary_${CEF_VERSION}_macosarm64" ;;
+    x86_64) echo "cef_binary_${CEF_VERSION}_macosx64" ;;
+  esac
+}
+
+# Fail early if a build artifact does not contain every architecture it should.
+# Guards the lipo merge below: a missing slice only shows up as a link error in
+# the host app (or a helper that cannot launch), far from its cause.
+verify_archs() {
+  local path="$1" have missing=()
+  have="$(lipo -archs "${path}" 2>/dev/null)" || err "cannot read architectures of ${path}"
+  for want in "${ARCHS[@]}"; do
+    case " ${have} " in
+      *" ${want} "*) ;;
+      *) missing+=("${want}") ;;
+    esac
+  done
+  [ ${#missing[@]} -eq 0 ] || err "${path} is missing the ${missing[*]} slice(s) (has: ${have})"
+}
+
 STAMP="${DEST}/version.txt"
-WANT="${CEF_VERSION}_${CEF_ARCH}_${BUILD_TYPE}"
+WANT="${CEF_VERSION}_${ARCH_TAG}_${BUILD_TYPE}"
 
 # --- skip if already prepared for this exact version/arch/type ---------------
 if [ -f "${STAMP}" ] && [ "$(cat "${STAMP}" 2>/dev/null)" = "${WANT}" ] \
@@ -63,36 +108,55 @@ fi
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/cef_dl.XXXXXX")"
 trap 'rm -rf "${WORK}"' EXIT
-TARBALL="${WORK}/${PKG}.tar.bz2"
-# CDN requires '+' percent-encoded as %2B.
-URL="${CDN}/$(printf '%s' "${PKG}.tar.bz2" | sed 's/+/%2B/g')"
 
-echo "==> Downloading ${PKG}.tar.bz2"
-curl -L --fail --connect-timeout 30 -o "${TARBALL}" "${URL}"
+# --- fetch and build one distribution per requested architecture -------------
+for arch in "${ARCHS[@]}"; do
+  pkg="$(cef_package "${arch}")"
+  tarball="${WORK}/${pkg}.tar.bz2"
+  # CDN requires '+' percent-encoded as %2B.
+  url="${CDN}/$(printf '%s' "${pkg}.tar.bz2" | sed 's/+/%2B/g')"
 
-echo "==> Extracting"
-tar -xjf "${TARBALL}" -C "${WORK}"
-SRC="${WORK}/${PKG}"
-[ -d "${SRC}" ] || err "extracted dir ${SRC} not found"
+  echo "==> Downloading ${pkg}.tar.bz2"
+  curl -L --fail --connect-timeout 30 -o "${tarball}" "${url}"
 
-echo "==> Building libcef_dll_wrapper (${BUILD_TYPE}, ${PROJECT_ARCH})"
-cmake -S "${SRC}" -B "${SRC}/build" -G "${GENERATOR}" \
-  -DPROJECT_ARCH="${PROJECT_ARCH}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 >/dev/null
-( cd "${SRC}/build" && "${BUILD_TOOL[@]}" >/dev/null )
-WRAPPER="${SRC}/build/libcef_dll_wrapper/libcef_dll_wrapper.a"
-[ -f "${WRAPPER}" ] || err "libcef_dll_wrapper.a was not produced"
+  echo "==> Extracting ${arch}"
+  tar -xjf "${tarball}" -C "${WORK}"
+  rm -f "${tarball}"
+  [ -d "${WORK}/${pkg}" ] || err "extracted dir ${WORK}/${pkg} not found"
+
+  echo "==> Building libcef_dll_wrapper (${BUILD_TYPE}, ${arch})"
+  cmake -S "${WORK}/${pkg}" -B "${WORK}/${pkg}/build" -G "${GENERATOR}" \
+    -DPROJECT_ARCH="${arch}" -DCMAKE_OSX_ARCHITECTURES="${arch}" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 >/dev/null
+  ( cd "${WORK}/${pkg}/build" && "${BUILD_TOOL[@]}" >/dev/null )
+  [ -f "${WORK}/${pkg}/build/libcef_dll_wrapper/libcef_dll_wrapper.a" ] \
+    || err "libcef_dll_wrapper.a was not produced for ${arch}"
+done
+
+PRIMARY="${WORK}/$(cef_package "${ARCHS[0]}")"
 
 echo "==> Installing into ${DEST}"
 rm -rf "${DEST}/include" "${DEST}/Chromium Embedded Framework.framework" \
-       "${DEST}/libcef_dll_wrapper.a" "${STAMP}"
+       "${DEST}/libcef_dll_wrapper.a" "${DEST}/cef_helper" "${STAMP}"
 mkdir -p "${DEST}"
-cp -R "${SRC}/include" "${DEST}/include"
-cp "${WRAPPER}" "${DEST}/libcef_dll_wrapper.a"
+# Headers are identical across the per-arch distributions.
+cp -R "${PRIMARY}/include" "${DEST}/include"
+
+# Merge (or copy) the wrapper. lipo on a single input is a plain copy, so the
+# universal and single-arch paths stay the same code.
+wrappers=()
+for arch in "${ARCHS[@]}"; do
+  wrappers+=("${WORK}/$(cef_package "${arch}")/build/libcef_dll_wrapper/libcef_dll_wrapper.a")
+done
+lipo -create "${wrappers[@]}" -output "${DEST}/libcef_dll_wrapper.a"
+verify_archs "${DEST}/libcef_dll_wrapper.a"
 
 # Lay the framework out as a versioned macOS bundle (Xcode embed/sign requires
-# Versions/Current/Resources/Info.plist; CEF ships a flat bundle).
-FW_SRC="${SRC}/Release/Chromium Embedded Framework.framework"
+# Versions/Current/Resources/Info.plist; CEF ships a flat bundle). The Resources
+# (locales, .pak/.dat blobs) are architecture independent, so they are taken
+# from the primary distribution; the Mach-O parts are merged.
+FW_SRC="${PRIMARY}/Release/Chromium Embedded Framework.framework"
 FW_DST="${DEST}/Chromium Embedded Framework.framework"
 mkdir -p "${FW_DST}/Versions/A"
 cp -R "${FW_SRC}/Chromium Embedded Framework" "${FW_DST}/Versions/A/"
@@ -103,12 +167,37 @@ ln -sfn "Versions/Current/Chromium Embedded Framework" "${FW_DST}/Chromium Embed
 ln -sfn Versions/Current/Libraries "${FW_DST}/Libraries"
 ln -sfn Versions/Current/Resources "${FW_DST}/Resources"
 
+if [ "${#ARCHS[@]}" -gt 1 ]; then
+  echo "==> Merging framework binaries (${ARCHS[*]})"
+  # The framework binary plus the ANGLE/SwiftShader dylibs next to it are the
+  # only Mach-O files in the bundle. Each slice keeps its own code signature,
+  # so the merged files stay loadable without re-signing.
+  merge_into_framework() {
+    local rel="$1" inputs=()
+    for arch in "${ARCHS[@]}"; do
+      inputs+=("${WORK}/$(cef_package "${arch}")/Release/Chromium Embedded Framework.framework/${rel}")
+    done
+    lipo -create "${inputs[@]}" -output "${FW_DST}/Versions/A/${rel}"
+    verify_archs "${FW_DST}/Versions/A/${rel}"
+  }
+  merge_into_framework "Chromium Embedded Framework"
+  for lib in "${FW_SRC}/Libraries/"*.dylib; do
+    merge_into_framework "Libraries/$(basename "${lib}")"
+  done
+fi
+verify_archs "${FW_DST}/Versions/A/Chromium Embedded Framework"
+
 # Build the standalone CEF helper executable used by the multi-process helper
 # bundles (embed_cef_helpers.sh clones this into the 5 named .app bundles).
 # It links the wrapper statically; the framework is dlopen'd at runtime
 # (LoadInHelper), so it does not link the framework here.
-echo "==> Building CEF helper executable"
+echo "==> Building CEF helper executable (${ARCHS[*]})"
+arch_flags=()
+for arch in "${ARCHS[@]}"; do
+  arch_flags+=(-arch "${arch}")
+done
 clang++ -std=c++20 -stdlib=libc++ -mmacosx-version-min=12.0 -w \
+  "${arch_flags[@]}" \
   -I "${DEST}" -I "${REPO_ROOT}/common" \
   "${MACOS_DIR}/helper/cef_helper_main.mm" \
   "${DEST}/libcef_dll_wrapper.a" \
@@ -116,6 +205,7 @@ clang++ -std=c++20 -stdlib=libc++ -mmacosx-version-min=12.0 -w \
   -Wl,-ObjC \
   -o "${DEST}/cef_helper"
 [ -f "${DEST}/cef_helper" ] || err "cef_helper was not produced"
+verify_archs "${DEST}/cef_helper"
 
 echo "${WANT}" > "${STAMP}"
-echo "==> Done: CEF ${CEF_VERSION} (${CEF_ARCH}, wrapper ${BUILD_TYPE}) ready in ${DEST}"
+echo "==> Done: CEF ${CEF_VERSION} (${ARCH_TAG}, wrapper ${BUILD_TYPE}) ready in ${DEST}"

--- a/macos/scripts/embed_cef_helpers.sh
+++ b/macos/scripts/embed_cef_helpers.sh
@@ -21,6 +21,24 @@ if [ ! -f "${HELPER_BIN}" ]; then
   exit 0
 fi
 
+# The helper is prepared by download_cef.sh for the architectures selected with
+# WEBVIEW_CEF_MACOS_ARCH. If the app is being built for an architecture the
+# helper does not contain, the bundles would embed fine and then fail to launch
+# at runtime on that architecture, so fail the build with an actionable message.
+if [ -n "${ARCHS:-}" ]; then
+  helper_archs="$(lipo -archs "${HELPER_BIN}" 2>/dev/null || echo "")"
+  for arch in ${ARCHS}; do
+    case " ${helper_archs} " in
+      *" ${arch} "*) ;;
+      *)
+        echo "error: webview_cef helper has no ${arch} slice (has: ${helper_archs:-none}) while building for '${ARCHS}'." >&2
+        echo "note: re-run pod install with WEBVIEW_CEF_MACOS_ARCH=universal to prepare a universal CEF." >&2
+        exit 1
+        ;;
+    esac
+  done
+fi
+
 BASE="${EXECUTABLE_NAME} Helper"
 DEST="${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:--}"

--- a/macos/webview_cef.podspec
+++ b/macos/webview_cef.podspec
@@ -2,16 +2,23 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint webview_cef.podspec` to validate before publishing.
 #
+# Metadata mirrors pubspec.yaml; the version is read from it so the two cannot
+# drift apart (this pod is consumed by path, never published to trunk).
+pubspec = File.read(File.join(__dir__, '..', 'pubspec.yaml'))
+plugin_version = pubspec[/^version:\s*(\S+)/, 1] or
+  raise 'webview_cef: could not read version from pubspec.yaml'
+
 Pod::Spec.new do |s|
   s.name             = 'webview_cef'
-  s.version          = '0.2.3'
+  s.version          = plugin_version
   s.summary          = 'Flutter webview backed by CEF (Chromium Embedded Framework)'
   s.description      = <<-DESC
-Flutter webview backed by CEF (Chromium Embedded Framework)
+Flutter desktop webview backed by CEF (Chromium Embedded Framework). Renders
+Chromium off-screen and presents it inside a Flutter Texture.
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://github.com/hlwhl/webview_cef'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'hlwhl' => 'https://github.com/hlwhl/webview_cef' }
 
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'

--- a/macos/webview_cef.podspec
+++ b/macos/webview_cef.podspec
@@ -33,21 +33,27 @@ Flutter webview backed by CEF (Chromium Embedded Framework)
   s.xcconfig = { "HEADER_SEARCH_PATHS" => $dir}
   # s.private_header_files = '../common/simple_app.h', '../common/simple_handler.h'
 
-  # CEF ships separate per-architecture macOS binaries; scripts/download_cef.sh
-  # fetches the one matching the build host (arm64 -> macosarm64, x86_64 ->
-  # macosx64). Exclude the other architecture so a default (universal)
-  # `flutter build macos` doesn't try to link a slice the CEF framework/wrapper
-  # doesn't provide — that fails with "symbol(s) not found for architecture
-  # x86_64". A universal app would require a lipo'd CEF, which is out of scope.
-  host_arch = `uname -m`.strip
-  non_host_arch = (host_arch == 'arm64') ? 'x86_64' : 'arm64'
+  # CEF ships separate per-architecture macOS binaries. scripts/download_cef.sh
+  # prepares the slices selected by WEBVIEW_CEF_MACOS_ARCH (host, arm64, x86_64
+  # or universal, defaulting to the build host) and this podspec must exclude
+  # every architecture it did not prepare — otherwise the link fails with
+  # "symbol(s) not found for architecture x86_64". Both are read from the same
+  # environment variable, so the two always agree.
+  requested_arch = (ENV['WEBVIEW_CEF_MACOS_ARCH'] || 'host').strip
+  requested_arch = `uname -m`.strip if requested_arch == 'host'
+  excluded_archs = case requested_arch
+                   when 'arm64'     then 'x86_64'
+                   when 'x86_64'    then 'arm64'
+                   when 'universal' then ''
+                   else raise "webview_cef: WEBVIEW_CEF_MACOS_ARCH must be host, arm64, x86_64 or universal (got '#{requested_arch}')"
+                   end
 
   s.platform = :osx, '12.0'
   # CEF 149 public headers require C++20.
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
-    "EXCLUDED_ARCHS[sdk=macosx*]" => non_host_arch,
+    "EXCLUDED_ARCHS[sdk=macosx*]" => excluded_archs,
     # Zero-copy GPU rendering: CEF delivers frames as a shared-texture IOSurface
     # via OnAcceleratedPaint instead of a software CPU buffer (OnPaint). The IME
     # and frame plumbing key off this define in the shared common/ sources.
@@ -55,6 +61,6 @@ Flutter webview backed by CEF (Chromium Embedded Framework)
   }
   # The app target links the CEF framework/wrapper too, so it must drop the same
   # architecture or its slice fails to link.
-  s.user_target_xcconfig = { "EXCLUDED_ARCHS[sdk=macosx*]" => non_host_arch }
+  s.user_target_xcconfig = { "EXCLUDED_ARCHS[sdk=macosx*]" => excluded_archs }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
Follow-up to #208, reworked on top of current main as you asked.

**Universal builds.** Adds `WEBVIEW_CEF_MACOS_ARCH`: `host` (default, unchanged behaviour), `arm64`, `x86_64`, `universal`. The download script and the podspec read the same variable, so the prepared slices and `EXCLUDED_ARCHS` can't drift apart. For `universal` the script downloads both distributions, builds the wrapper twice, and `lipo`s the wrapper, the framework binary, the ANGLE/SwiftShader dylibs and `cef_helper`; headers and resources are arch-independent so they come from one distribution.

Validation:
- each merged artifact is checked with `lipo -archs`, so a missing slice fails during `pod install`, not as a link error later
- the helper embed phase fails the build if the helper doesn't cover the target's `ARCHS` (otherwise the bundles embed fine and can't launch on the other arch)
- new CI job builds the example universal and asserts the app binary, framework, dylibs and all five helper bundles are fat

Tested locally on arm64: `flutter build macos --release` produced a universal app (all 11 binaries `x86_64 arm64`) and it ran multi-process. I have no Intel machine, so the x86_64 slice itself is unverified beyond the checks above.

Universal is opt-in because it roughly doubles prepare time and needs ~8 GB scratch.

**Also picked up the two leftovers from #208** (separate commits, drop them if you'd rather):

- CI no longer pins CEF a second time. The macOS job carried its own `CEF_VERSION`, so bumping `third/download.cmake` left CI on the old version, and it built a Release wrapper that `pod install` then discarded and re-downloaded. It now runs `macos/scripts/download_cef.sh`, the same auto-download the podspec's `prepare_command` uses.
- Podspec metadata: `version` said 0.2.3 with pubspec.yaml at 0.6.1, `homepage`/`author` were the template defaults. Version is now read from pubspec.yaml.

One thing this surfaced: `CEF_WRAPPER_BUILD_TYPE=Release` is broken on main, independent of architecture. The wrapper gets built with `NDEBUG` while `cef_helper` and the plugin are compiled without it, so `DCHECK_IS_ON()` disagrees and the helper fails to link on `base::cef_subtle::RefCountedThreadSafeBase::~RefCountedThreadSafeBase()`. Left alone here — happy to fix it separately.

CHANGELOG entry is under `Unreleased`; move it wherever suits your release flow.
