### PR TITLE
macOS: drop the duplicated CEF version pin in CI, fix podspec metadata

### DIFF
--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -31,22 +31,12 @@ jobs:
           channel: stable
       - name: Install build tools
         run: brew install ninja cmake
-      # macOS uses CocoaPods (not third/download.cmake), so the CEF framework and
-      # libcef_dll_wrapper must be placed into macos/third/cef manually.
-      # Keep CEF_VERSION in sync with third/download.cmake.
+      # Prepare macos/third/cef with the same script the podspec's
+      # prepare_command runs, so the CEF version comes from third/download.cmake
+      # instead of being pinned a second time here. `pod install` then finds it
+      # already prepared and does not download CEF again.
       - name: Download CEF and build libcef_dll_wrapper
-        run: |
-          set -eo pipefail
-          CEF_VERSION="149.0.4+g2f1bfd8+chromium-149.0.7827.156"
-          NAME="cef_binary_${CEF_VERSION}_macosarm64"
-          URL_NAME=$(printf '%s' "$NAME" | sed 's/+/%2B/g')
-          curl -L -o cef.tar.bz2 "https://cef-builds.spotifycdn.com/${URL_NAME}.tar.bz2"
-          tar -xjf cef.tar.bz2
-          cmake -S "$NAME" -B "$NAME/build" -G Ninja -DPROJECT_ARCH=arm64 -DCMAKE_BUILD_TYPE=Release
-          cmake --build "$NAME/build" --target libcef_dll_wrapper
-          mkdir -p macos/third/cef
-          cp -R "$NAME/Release/Chromium Embedded Framework.framework" macos/third/cef/
-          cp "$NAME/build/libcef_dll_wrapper/libcef_dll_wrapper.a" macos/third/cef/
+        run: bash macos/scripts/download_cef.sh
       - run: flutter --version
       - name: Analyze plugin
         run: flutter analyze

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ These CMake options can be set on the plugin target (defaults shown):
 
 ## Updating CEF
 
-The CEF/Chromium version is pinned in one place — `CEF_VERSION` in [`third/download.cmake`](third/download.cmake). Bump it to update CEF on all three platforms: Windows and Linux download it automatically, and macOS reads the same `CEF_VERSION` (via `macos/scripts/download_cef.sh`, run by the podspec's `prepare_command`) and re-downloads on the next `pod install` — no manual placement needed. The only extra step is keeping the hardcoded `CEF_VERSION` in [`.github/workflows/test_macos.yaml`](.github/workflows/test_macos.yaml) in sync.
+The CEF/Chromium version is pinned in one place — `CEF_VERSION` in [`third/download.cmake`](third/download.cmake). Bump it to update CEF on all three platforms: Windows and Linux download it automatically, and macOS reads the same `CEF_VERSION` (via `macos/scripts/download_cef.sh`, run by the podspec's `prepare_command`) and re-downloads on the next `pod install` — no manual placement needed.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -274,7 +274,7 @@ final controller = WebviewManager().createWebView(injectUserScripts: scripts);
 
 ## 升级 CEF
 
-CEF/Chromium 版本只在一处管理 —— [`third/download.cmake`](third/download.cmake) 里的 `CEF_VERSION`。修改它即可升级三端的 CEF：Windows 与 Linux 自动下载，macOS 也读取同一个 `CEF_VERSION`（通过 podspec `prepare_command` 运行的 [`macos/scripts/download_cef.sh`](macos/scripts/download_cef.sh)），在下次 `pod install` 时重新下载，无需手动放置。唯一的额外步骤是同步 [`.github/workflows/test_macos.yaml`](.github/workflows/test_macos.yaml) 里硬编码的 `CEF_VERSION`。
+CEF/Chromium 版本只在一处管理 —— [`third/download.cmake`](third/download.cmake) 里的 `CEF_VERSION`。修改它即可升级三端的 CEF：Windows 与 Linux 自动下载，macOS 也读取同一个 `CEF_VERSION`（通过 podspec `prepare_command` 运行的 [`macos/scripts/download_cef.sh`](macos/scripts/download_cef.sh)），在下次 `pod install` 时重新下载，无需手动放置。
 
 ---
 

--- a/macos/webview_cef.podspec
+++ b/macos/webview_cef.podspec
@@ -2,16 +2,23 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint webview_cef.podspec` to validate before publishing.
 #
+# Metadata mirrors pubspec.yaml; the version is read from it so the two cannot
+# drift apart (this pod is consumed by path, never published to trunk).
+pubspec = File.read(File.join(__dir__, '..', 'pubspec.yaml'))
+plugin_version = pubspec[/^version:\s*(\S+)/, 1] or
+  raise 'webview_cef: could not read version from pubspec.yaml'
+
 Pod::Spec.new do |s|
   s.name             = 'webview_cef'
-  s.version          = '0.2.3'
+  s.version          = plugin_version
   s.summary          = 'Flutter webview backed by CEF (Chromium Embedded Framework)'
   s.description      = <<-DESC
-Flutter webview backed by CEF (Chromium Embedded Framework)
+Flutter desktop webview backed by CEF (Chromium Embedded Framework). Renders
+Chromium off-screen and presents it inside a Flutter Texture.
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://github.com/hlwhl/webview_cef'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'hlwhl' => 'https://github.com/hlwhl/webview_cef' }
 
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'


### PR DESCRIPTION
Two small macOS build-config cleanups left over from #208, split out from #220 (they don't overlap — different parts of the workflow file).

**CI no longer pins CEF twice.** The macOS job downloaded and built CEF with its own copy of `CEF_VERSION`, so bumping `third/download.cmake` left CI on the old version until the workflow was edited too. It also built the wrapper in Release while the job builds the example in Debug, so `pod install`'s `prepare_command` threw that away and downloaded CEF again. The step now just runs `macos/scripts/download_cef.sh`, which reads `third/download.cmake` and produces exactly what `pod install` then finds already prepared. Removed the matching "keep it in sync" note from both READMEs.

**Podspec metadata.** `version` said 0.2.3 with pubspec.yaml at 0.6.1, and `homepage`/`author` were still the template defaults (`http://example.com`, `Your Company`). The version is now read from pubspec.yaml so it can't drift again; homepage and author point at the repository. Cosmetic — the pod is consumed by path, never published to trunk — but `pod install` prints it and it shows up in `Podfile.lock`.

Verified `pod install` resolves `webview_cef (0.6.1)` through the symlinked plugin path.
